### PR TITLE
feat(schema): enhance action schema validation and update input/outpu…

### DIFF
--- a/action.schema.yaml
+++ b/action.schema.yaml
@@ -105,9 +105,6 @@ inputs:
   bypass-validation:
     type: boolean
 
-  extension-tag:
-    type: string
-
   update-tasks-version:
     type: choice
     options:
@@ -128,13 +125,7 @@ inputs:
   vsix-path:
     type: string
 
-  validation-timeout:
-    type: number
-
-  validation-poll-interval:
-    type: number
-
-  skip-validation:
+  no-wait-validation:
     type: boolean
 
   expected-tasks:
@@ -143,22 +134,31 @@ inputs:
     items:
       type: string
 
-  installation-timeout:
-    type: number
-
-  installation-poll-interval:
-    type: number
-
-  increment-version:
+  version-action:
     type: choice
     options:
-      - major
-      - minor
-      - patch
-      - none
+      - None
+      - Major
+      - Minor
+      - Patch
 
-  tag-prefix:
+  extension-version-override:
     type: string
+
+  max-retries:
+    type: number
+
+  min-timeout:
+    type: number
+
+  max-timeout:
+    type: number
+
+  timeout-minutes:
+    type: number
+
+  polling-interval-seconds:
+    type: number
 
 # Validate outputs
 outputs:

--- a/publish/action.schema.yaml
+++ b/publish/action.schema.yaml
@@ -88,7 +88,7 @@ inputs:
   output-path:
     type: string
 
-  bypass-validation:
+  no-wait-validation:
     type: boolean
 
   update-tasks-version:
@@ -106,6 +106,3 @@ inputs:
 outputs:
   vsix-path:
     type: string
-
-  published:
-    type: boolean

--- a/query-version/action.schema.yaml
+++ b/query-version/action.schema.yaml
@@ -40,24 +40,21 @@ inputs:
   extension-id:
     type: identifier
 
-  vsix-path:
-    type: string
-
-  increment-version:
+  version-action:
     type: choice
     options:
-      - major
-      - minor
-      - patch
-      - none
+      - None
+      - Major
+      - Minor
+      - Patch
 
-  tag-prefix:
+  extension-version-override:
     type: string
 
 # Validate outputs
 outputs:
-  extension-version:
+  current-version:
     type: semver
 
-  new-version:
+  proposed-version:
     type: semver

--- a/share/action.schema.yaml
+++ b/share/action.schema.yaml
@@ -45,8 +45,3 @@ inputs:
     separators: newline
     items:
       type: string
-
-# Validate outputs
-outputs:
-  shared:
-    type: boolean

--- a/show/action.schema.yaml
+++ b/show/action.schema.yaml
@@ -37,9 +37,6 @@ inputs:
   extension-id:
     type: identifier
 
-  vsix-path:
-    type: string
-
 # Validate outputs
 outputs:
   metadata:

--- a/unshare/action.schema.yaml
+++ b/unshare/action.schema.yaml
@@ -45,8 +45,3 @@ inputs:
     separators: newline
     items:
       type: string
-
-# Validate outputs
-outputs:
-  unshared:
-    type: boolean

--- a/wait-for-installation/action.schema.yaml
+++ b/wait-for-installation/action.schema.yaml
@@ -52,13 +52,8 @@ inputs:
     items:
       type: string
 
-  installation-timeout:
+  timeout-minutes:
     type: number
 
-  installation-poll-interval:
+  polling-interval-seconds:
     type: number
-
-# Validate outputs
-outputs:
-  verify-install:
-    type: boolean

--- a/wait-for-validation/action.schema.yaml
+++ b/wait-for-validation/action.schema.yaml
@@ -46,16 +46,11 @@ inputs:
   extension-version:
     type: semver
 
-  validation-timeout:
+  max-retries:
     type: number
 
-  validation-poll-interval:
+  min-timeout:
     type: number
 
-  skip-validation:
-    type: boolean
-
-# Validate outputs
-outputs:
-  is-valid:
-    type: boolean
+  max-timeout:
+    type: number


### PR DESCRIPTION
…t definitions
This pull request introduces comprehensive schema validation for action input and output declarations and refactors the action schemas to improve consistency and clarity. The main focus is to ensure that all inputs and outputs are properly declared and aligned across `action.yml` and `action.schema.yaml` files, and to streamline and clarify input names and types across various action schemas.

**Schema validation and error handling:**

* Added strict cross-file validation in `Scripts/sync-action-inputs.mjs` to ensure that all inputs and outputs are consistently declared in both `action.yml` and `action.schema.yaml`, as well as in composite actions and their schemas. Validation errors are now collected and reported, causing the script to fail if inconsistencies are found. [[1]](diffhunk://#diff-7926d7329ad2309a82952c3224ac958e7acb35dc6cc432412d663970af33171cR140-R253) [[2]](diffhunk://#diff-7926d7329ad2309a82952c3224ac958e7acb35dc6cc432412d663970af33171cR264-R330)

**Action schema refactoring and input/output cleanup:**

* Standardized and renamed several inputs across action schemas for clarity (e.g., replaced `skip-validation` and `bypass-validation` with `no-wait-validation`, replaced `validation-timeout`/`installation-timeout` with `timeout-minutes`, and unified polling/interval naming). [[1]](diffhunk://#diff-3215daeec24ae0a5192a337c62f3e6bd6cbe58200648d03b5dbd7d8b4d16e9e6L131-R128) [[2]](diffhunk://#diff-3215daeec24ae0a5192a337c62f3e6bd6cbe58200648d03b5dbd7d8b4d16e9e6L146-R161) [[3]](diffhunk://#diff-3ffcac8ada8a3fc29ccbd0d2ea0deec7a2c1542760d9f0091a8f4d216211dfcaL91-R91) [[4]](diffhunk://#diff-dfdcef4f73ce069db3c574fd7ece0045ede4af27b68bf8c5d78b220e71335558L55-L64) [[5]](diffhunk://#diff-0aaa6ccdbe5f19058975daf19454104eeec7302a0107062eab9f7774fdfdf354L49-R56)
* Updated versioning-related inputs: replaced `increment-version` with `version-action` and introduced `extension-version-override` for more explicit version control. [[1]](diffhunk://#diff-3215daeec24ae0a5192a337c62f3e6bd6cbe58200648d03b5dbd7d8b4d16e9e6L146-R161) [[2]](diffhunk://#diff-31ab9f8f7e67bc02ee49d51871842be5046f72c253a06b99bf408d010cfa2630L43-R59)
* Removed unused or redundant inputs and outputs from action schemas, such as `extension-tag`, `vsix-path` (where not needed), and boolean outputs like `published`, `shared`, `unshared`, and `is-valid`. [[1]](diffhunk://#diff-3215daeec24ae0a5192a337c62f3e6bd6cbe58200648d03b5dbd7d8b4d16e9e6L108-L110) [[2]](diffhunk://#diff-3ffcac8ada8a3fc29ccbd0d2ea0deec7a2c1542760d9f0091a8f4d216211dfcaL109-L111) [[3]](diffhunk://#diff-caa3e11c5135264848a7d5d85c7e050a7656fe19a9ab7bdf2c30859a6080e581L48-L52) [[4]](diffhunk://#diff-0487071324bb5925666acfa3f20fbf553183a8d93fedb2f924969291c9d01a34L40-L42) [[5]](diffhunk://#diff-dfdcef4f73ce069db3c574fd7ece0045ede4af27b68bf8c5d78b220e71335558L55-L64) [[6]](diffhunk://#diff-0aaa6ccdbe5f19058975daf19454104eeec7302a0107062eab9f7774fdfdf354L49-R56)

**Consistency improvements in output naming:**

* Updated output names for clarity and consistency, e.g., `extension-version` → `current-version`, `new-version` → `proposed-version`.

**Code logic correction:**

* Fixed logic in the output comparison loop in `sync-action-inputs.mjs` to ensure correct handling of outputs between root and composite actions.