### PR TITLE
chore: update azure-pipelines-task-lib to version 5.2.7 and azure-pip…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3548,30 +3548,18 @@
       }
     },
     "node_modules/azure-pipelines-task-lib": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.6.tgz",
-      "integrity": "sha512-YWEJFAY+Imk5nWwPd5ao6h/J8BgW2Dtzt+M5QiUWDV5cB10n4zywQ5Dulj2OcO1B9tGfdV5KDKVnQRKfJ72YmA==",
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-5.2.7.tgz",
+      "integrity": "sha512-UtA7gDfo7P/mBymx8mi9rkavLU8gu1T1ySoQAZRaC6NEJ4epvEPTaP/3lvlC1mS+Lu2Twt//aMrDbolxSYeMZQ==",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
+        "minimatch": "^3.1.5",
         "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
         "semver": "^5.7.2",
         "shelljs": "^0.10.0",
         "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-task-lib/node_modules/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/azure-pipelines-task-lib/node_modules/semver": {
@@ -3638,9 +3626,9 @@
       }
     },
     "node_modules/azure-pipelines-tasks-azure-arm-rest": {
-      "version": "3.271.1",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.271.1.tgz",
-      "integrity": "sha512-HwAmG4h3Q4jAUdeDCR40nQERNfhglMBcG4w+iXHYMswgnZKd3uvHCTBh2UjXDARoxdgezcLvUK3H18HVrXBTFA==",
+      "version": "3.271.2",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tasks-azure-arm-rest/-/azure-pipelines-tasks-azure-arm-rest-3.271.2.tgz",
+      "integrity": "sha512-A3jGDwSshMhFYm9fDZp3DfbmfNdKixkqbvMWqs7yVpb8Kddk5L3N5u2bUdFAnic11aki5M2qRsHa0vVFTjCIuQ==",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.2.1",
@@ -11130,9 +11118,9 @@
       "version": "6.0.0-alpha.1",
       "dependencies": {
         "@extension-tasks/core": "*",
-        "azure-pipelines-task-lib": "^5.2.6",
+        "azure-pipelines-task-lib": "^5.2.7",
         "azure-pipelines-tasks-artifacts-common": "^2.270.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.271.1",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.271.2",
         "azure-pipelines-tool-lib": "^2.0.10"
       },
       "devDependencies": {

--- a/packages/azdo-task/package.json
+++ b/packages/azdo-task/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@extension-tasks/core": "*",
-    "azure-pipelines-task-lib": "^5.2.6",
+    "azure-pipelines-task-lib": "^5.2.7",
     "azure-pipelines-tasks-artifacts-common": "^2.270.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.271.1",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.271.2",
     "azure-pipelines-tool-lib": "^2.0.10"
   },
   "devDependencies": {


### PR DESCRIPTION
…elines-tasks-azure-arm-rest to version 3.271.2

This pull request updates dependency versions in the `packages/azdo-task/package.json` file to ensure compatibility and incorporate the latest fixes.

Dependency updates:

* Upgraded `azure-pipelines-task-lib` from version `^5.2.6` to `^5.2.7`.
* Upgraded `azure-pipelines-tasks-azure-arm-rest` from version `^3.271.1` to `^3.271.2`.