### PR TITLE
fix: ensures that task version and ID handling works for multi-version tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3727,45 +3727,18 @@
       }
     },
     "node_modules/azure-pipelines-tool-lib": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.10.tgz",
-      "integrity": "sha512-UiwgFUjbooyEpDQX/0eY6teTUjKXD5VDbe3USpLaFpjbzxI2/XglboA9fj86dQBFvMx6NVg0LKYtECflfYiJOQ==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-tool-lib/-/azure-pipelines-tool-lib-2.0.12.tgz",
+      "integrity": "sha512-PcqNdHQR7HyXAcX/gbQfounoTKM0DvBhWcwxC6z5BizDYRqJPXhG4D1OVB+QoffpI+1O7+eUYiXg97ujkbNqOQ==",
       "license": "MIT",
       "dependencies": {
         "@types/semver": "^5.3.0",
         "@types/uuid": "^3.4.5",
-        "azure-pipelines-task-lib": "^4.1.0",
+        "azure-pipelines-task-lib": "^5.2.7",
         "semver": "^5.7.0",
         "semver-compare": "^1.0.0",
         "typed-rest-client": "^1.8.6",
         "uuid": "^3.3.2"
-      }
-    },
-    "node_modules/azure-pipelines-tool-lib/node_modules/azure-pipelines-task-lib": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
-      "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "adm-zip": "^0.5.10",
-        "minimatch": "3.0.5",
-        "nodejs-file-downloader": "^4.11.1",
-        "q": "^1.5.1",
-        "semver": "^5.7.2",
-        "shelljs": "^0.8.5",
-        "uuid": "^3.0.1"
-      }
-    },
-    "node_modules/azure-pipelines-tool-lib/node_modules/minimatch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
-      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/azure-pipelines-tool-lib/node_modules/semver": {
@@ -3775,23 +3748,6 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
-      }
-    },
-    "node_modules/azure-pipelines-tool-lib/node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/azure-pipelines-tool-lib/node_modules/typed-rest-client": {
@@ -5621,6 +5577,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -5788,6 +5745,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -6095,6 +6053,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -6119,15 +6078,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6219,6 +6169,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -8257,6 +8208,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -8433,6 +8385,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8451,6 +8404,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -8812,17 +8766,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -8879,6 +8822,7 @@
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.16.1",
@@ -9738,6 +9682,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10830,6 +10775,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/packages/core/src/__tests__/filesystem-manifest-reader.test.ts
+++ b/packages/core/src/__tests__/filesystem-manifest-reader.test.ts
@@ -119,6 +119,18 @@ describe('FilesystemManifestReader', () => {
 
       writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(manifest));
 
+      // Create task.json files so findTaskPaths can discover them
+      mkdirSync(join(testDir, 'Task1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'Task1', 'task.json'),
+        JSON.stringify({ id: 'id1', name: 'Task1', version: { Major: 1, Minor: 0, Patch: 0 } })
+      );
+      mkdirSync(join(testDir, 'Task2'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'Task2', 'task.json'),
+        JSON.stringify({ id: 'id2', name: 'Task2', version: { Major: 1, Minor: 0, Patch: 0 } })
+      );
+
       const reader = new FilesystemManifestReader({
         rootFolder: testDir,
         platform: mockPlatform,
@@ -148,6 +160,285 @@ describe('FilesystemManifestReader', () => {
       const taskPaths = await reader.findTaskPaths();
 
       expect(taskPaths).toEqual([]);
+
+      await reader.close();
+    });
+
+    it('should discover multi-version tasks from subdirectories', async () => {
+      const manifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'MyTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(manifest));
+
+      // No task.json at root MyTask/, but subdirectories have task.json
+      mkdirSync(join(testDir, 'MyTask', 'v1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v1', 'task.json'),
+        JSON.stringify({ id: 'id-v1', name: 'MyTask', version: { Major: 1, Minor: 0, Patch: 0 } })
+      );
+      mkdirSync(join(testDir, 'MyTask', 'v2'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v2', 'task.json'),
+        JSON.stringify({ id: 'id-v2', name: 'MyTask', version: { Major: 2, Minor: 0, Patch: 0 } })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const taskPaths = await reader.findTaskPaths();
+
+      expect(taskPaths).toContain('MyTask/v1');
+      expect(taskPaths).toContain('MyTask/v2');
+      expect(taskPaths).toHaveLength(2);
+
+      await reader.close();
+    });
+
+    it('should ignore subdirectories without task.json in multi-version scan', async () => {
+      const manifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'MyTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(manifest));
+
+      mkdirSync(join(testDir, 'MyTask', 'v1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v1', 'task.json'),
+        JSON.stringify({ id: 'id-v1', name: 'MyTask', version: { Major: 1, Minor: 0, Patch: 0 } })
+      );
+      // v2 has no task.json — should be ignored
+      mkdirSync(join(testDir, 'MyTask', 'v2'), { recursive: true });
+      writeFileSync(join(testDir, 'MyTask', 'v2', 'README.md'), 'not a task');
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const taskPaths = await reader.findTaskPaths();
+
+      expect(taskPaths).toEqual(['MyTask/v1']);
+
+      await reader.close();
+    });
+
+    it('should mix single-version and multi-version contributions', async () => {
+      const manifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        contributions: [
+          {
+            id: 'single',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'SingleTask' },
+          },
+          {
+            id: 'multi',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'MultiTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(manifest));
+
+      // SingleTask has task.json directly
+      mkdirSync(join(testDir, 'SingleTask'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'SingleTask', 'task.json'),
+        JSON.stringify({
+          id: 'single-id',
+          name: 'SingleTask',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+
+      // MultiTask has subdirectories only
+      mkdirSync(join(testDir, 'MultiTask', 'v1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MultiTask', 'v1', 'task.json'),
+        JSON.stringify({
+          id: 'multi-v1',
+          name: 'MultiTask',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+      mkdirSync(join(testDir, 'MultiTask', 'v2'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MultiTask', 'v2', 'task.json'),
+        JSON.stringify({
+          id: 'multi-v2',
+          name: 'MultiTask',
+          version: { Major: 2, Minor: 0, Patch: 0 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const taskPaths = await reader.findTaskPaths();
+
+      expect(taskPaths).toContain('SingleTask');
+      expect(taskPaths).toContain('MultiTask/v1');
+      expect(taskPaths).toContain('MultiTask/v2');
+      expect(taskPaths).toHaveLength(3);
+
+      await reader.close();
+    });
+
+    it('should discover multi-version tasks with packagePath mapping', async () => {
+      const manifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        files: [{ path: 'compiled/cli', packagePath: 'CLI' }],
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'CLI' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(manifest));
+
+      // No task.json at compiled/cli/, but subdirectories have task.json
+      mkdirSync(join(testDir, 'compiled', 'cli', 'v1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'compiled', 'cli', 'v1', 'task.json'),
+        JSON.stringify({
+          id: 'cli-v1',
+          name: 'CLI-v1',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+      mkdirSync(join(testDir, 'compiled', 'cli', 'v2'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'compiled', 'cli', 'v2', 'task.json'),
+        JSON.stringify({
+          id: 'cli-v2',
+          name: 'CLI-v2',
+          version: { Major: 2, Minor: 0, Patch: 0 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const taskPaths = await reader.findTaskPaths();
+
+      expect(taskPaths).toContain('CLI/v1');
+      expect(taskPaths).toContain('CLI/v2');
+      expect(taskPaths).toHaveLength(2);
+
+      await reader.close();
+    });
+
+    it('should return empty when contribution folder does not exist', async () => {
+      const manifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'NonexistentTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(manifest));
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const taskPaths = await reader.findTaskPaths();
+
+      expect(taskPaths).toEqual([]);
+
+      await reader.close();
+    });
+
+    it('should discover multi-version tasks with per-version packagePath mappings', async () => {
+      const manifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        files: [
+          { path: 'build/legacy', packagePath: 'MyTask/v1' },
+          { path: 'dist/current', packagePath: 'MyTask/v2' },
+        ],
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'MyTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(manifest));
+
+      // Each version comes from its own source directory
+      mkdirSync(join(testDir, 'build', 'legacy'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'build', 'legacy', 'task.json'),
+        JSON.stringify({
+          id: 'task-v1',
+          name: 'MyTask',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+      mkdirSync(join(testDir, 'dist', 'current'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'dist', 'current', 'task.json'),
+        JSON.stringify({
+          id: 'task-v2',
+          name: 'MyTask',
+          version: { Major: 2, Minor: 0, Patch: 0 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const taskPaths = await reader.findTaskPaths();
+
+      expect(taskPaths).toContain('MyTask/v1');
+      expect(taskPaths).toContain('MyTask/v2');
+      expect(taskPaths).toHaveLength(2);
 
       await reader.close();
     });
@@ -218,6 +509,173 @@ describe('FilesystemManifestReader', () => {
       });
 
       await expect(reader.readTaskManifest('NonexistentTask')).rejects.toThrow(/not found/);
+
+      await reader.close();
+    });
+
+    it('should read multi-version task manifests by path', async () => {
+      const extManifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'MyTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(extManifest));
+
+      mkdirSync(join(testDir, 'MyTask', 'v1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v1', 'task.json'),
+        JSON.stringify({
+          id: 'task-v1',
+          name: 'MyTask',
+          friendlyName: 'My Task V1',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+
+      mkdirSync(join(testDir, 'MyTask', 'v2'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v2', 'task.json'),
+        JSON.stringify({
+          id: 'task-v2',
+          name: 'MyTaskV2',
+          friendlyName: 'My Task V2',
+          version: { Major: 2, Minor: 0, Patch: 0 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const v1 = await reader.readTaskManifest('MyTask/v1');
+      expect(v1.id).toBe('task-v1');
+      expect(v1.name).toBe('MyTask');
+      expect(v1.version.Major).toBe(1);
+
+      const v2 = await reader.readTaskManifest('MyTask/v2');
+      expect(v2.id).toBe('task-v2');
+      expect(v2.name).toBe('MyTaskV2');
+      expect(v2.version.Major).toBe(2);
+
+      await reader.close();
+    });
+
+    it('should read multi-version task manifests with packagePath mapping', async () => {
+      const extManifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        files: [{ path: 'compiled/cli', packagePath: 'CLI' }],
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'CLI' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(extManifest));
+
+      mkdirSync(join(testDir, 'compiled', 'cli', 'v1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'compiled', 'cli', 'v1', 'task.json'),
+        JSON.stringify({
+          id: 'cli-v1',
+          name: 'CLI-v1',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+
+      mkdirSync(join(testDir, 'compiled', 'cli', 'v2'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'compiled', 'cli', 'v2', 'task.json'),
+        JSON.stringify({
+          id: 'cli-v2',
+          name: 'CLI-v2',
+          version: { Major: 2, Minor: 0, Patch: 0 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      // CLI/v1 → compiled/cli/v1
+      const v1 = await reader.readTaskManifest('CLI/v1');
+      expect(v1.name).toBe('CLI-v1');
+
+      // CLI/v2 → compiled/cli/v2
+      const v2 = await reader.readTaskManifest('CLI/v2');
+      expect(v2.name).toBe('CLI-v2');
+
+      await reader.close();
+    });
+
+    it('should read multi-version task manifests with per-version packagePath mappings', async () => {
+      const extManifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        files: [
+          { path: 'build/legacy', packagePath: 'MyTask/v1' },
+          { path: 'dist/current', packagePath: 'MyTask/v2' },
+        ],
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'MyTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(extManifest));
+
+      mkdirSync(join(testDir, 'build', 'legacy'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'build', 'legacy', 'task.json'),
+        JSON.stringify({
+          id: 'task-v1',
+          name: 'MyTask',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+
+      mkdirSync(join(testDir, 'dist', 'current'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'dist', 'current', 'task.json'),
+        JSON.stringify({
+          id: 'task-v2',
+          name: 'MyTask',
+          version: { Major: 2, Minor: 0, Patch: 0 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      // MyTask/v1 → build/legacy
+      const v1 = await reader.readTaskManifest('MyTask/v1');
+      expect(v1.name).toBe('MyTask');
+      expect(v1.version).toEqual({ Major: 1, Minor: 0, Patch: 0 });
+
+      // MyTask/v2 → dist/current
+      const v2 = await reader.readTaskManifest('MyTask/v2');
+      expect(v2.name).toBe('MyTask');
+      expect(v2.version).toEqual({ Major: 2, Minor: 0, Patch: 0 });
 
       await reader.close();
     });
@@ -312,6 +770,66 @@ describe('FilesystemManifestReader', () => {
       expect(tasksInfo[1].name).toBe('Task2');
       expect(tasksInfo[1].friendlyName).toBe('Second Task');
       expect(tasksInfo[1].version).toBe('2.1.3');
+
+      await reader.close();
+    });
+
+    it('should return info for multi-version tasks with correct paths', async () => {
+      const extManifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'MyTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(extManifest));
+
+      mkdirSync(join(testDir, 'MyTask', 'v1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v1', 'task.json'),
+        JSON.stringify({
+          id: 'id-v1',
+          name: 'MyTask',
+          friendlyName: 'My Task V1',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+
+      mkdirSync(join(testDir, 'MyTask', 'v2'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v2', 'task.json'),
+        JSON.stringify({
+          id: 'id-v2',
+          name: 'MyTaskV2',
+          friendlyName: 'My Task V2',
+          version: { Major: 2, Minor: 3, Patch: 1 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const tasksInfo = await reader.getTasksInfo();
+
+      expect(tasksInfo).toHaveLength(2);
+
+      const v1 = tasksInfo.find((t) => t.path === 'MyTask/v1');
+      expect(v1).toBeDefined();
+      expect(v1.name).toBe('MyTask');
+      expect(v1.version).toBe('1.0.0');
+
+      const v2 = tasksInfo.find((t) => t.path === 'MyTask/v2');
+      expect(v2).toBeDefined();
+      expect(v2.name).toBe('MyTaskV2');
+      expect(v2.version).toBe('2.3.1');
 
       await reader.close();
     });
@@ -543,7 +1061,7 @@ describe('FilesystemManifestReader', () => {
       await reader.close();
     });
 
-    it('should support packagePath prefix matching for nested subdirectories', async () => {
+    it('should support packagePath prefix matching for subdirectories', async () => {
       const manifest = {
         id: 'test-ext',
         publisher: 'test-pub',
@@ -560,10 +1078,10 @@ describe('FilesystemManifestReader', () => {
 
       writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(manifest));
 
-      // Create task in nested subdirectory: build/tasks/installer/v3/task.json
-      mkdirSync(join(testDir, 'build', 'tasks', 'installer', 'v3'), { recursive: true });
+      // Create task in subdirectory (1 level deep): build/tasks/v3/task.json
+      mkdirSync(join(testDir, 'build', 'tasks', 'v3'), { recursive: true });
       writeFileSync(
-        join(testDir, 'build', 'tasks', 'installer', 'v3', 'task.json'),
+        join(testDir, 'build', 'tasks', 'v3', 'task.json'),
         JSON.stringify({
           id: 'installer-v3',
           name: 'Installer-v3',
@@ -576,8 +1094,8 @@ describe('FilesystemManifestReader', () => {
         platform: mockPlatform,
       });
 
-      // When reading 'Tasks/installer/v3', should map to 'build/tasks/installer/v3'
-      const task = await reader.readTaskManifest('Tasks/installer/v3');
+      // When reading 'Tasks/v3', should map to 'build/tasks/v3'
+      const task = await reader.readTaskManifest('Tasks/v3');
       expect(task.name).toBe('Installer-v3');
       expect(task.version).toEqual({ Major: 3, Minor: 5, Patch: 1 });
 

--- a/packages/core/src/__tests__/filesystem-manifest-writer.test.ts
+++ b/packages/core/src/__tests__/filesystem-manifest-writer.test.ts
@@ -591,7 +591,7 @@ describe('FilesystemManifestWriter', () => {
       const editor = ManifestEditor.fromReader(reader);
 
       // Update task version for CLI/v2
-      const task = await reader.readTaskManifest('CLI/v2');
+
       await editor.updateTaskVersion('CLI/v2', '2.5.3', 'major');
 
       const writer = await editor.toWriter();
@@ -800,7 +800,7 @@ describe('FilesystemManifestWriter', () => {
       const editor = ManifestEditor.fromReader(reader);
 
       // Update TaskOther
-      const task = await reader.readTaskManifest('TaskOther');
+
       await editor.updateTaskVersion('TaskOther', '2.0.0', 'major');
 
       const writer = await editor.toWriter();

--- a/packages/core/src/__tests__/filesystem-manifest-writer.test.ts
+++ b/packages/core/src/__tests__/filesystem-manifest-writer.test.ts
@@ -592,7 +592,7 @@ describe('FilesystemManifestWriter', () => {
 
       // Update task version for CLI/v2
       const task = await reader.readTaskManifest('CLI/v2');
-      await editor.updateTaskVersion(task.name, '2.5.3', 'major');
+      await editor.updateTaskVersion('CLI/v2', '2.5.3', 'major');
 
       const writer = await editor.toWriter();
       await writer.writeToFilesystem();
@@ -609,7 +609,7 @@ describe('FilesystemManifestWriter', () => {
       await reader.close();
     });
 
-    it('should handle nested subdirectories with packagePath mapping', async () => {
+    it('should handle subdirectories with packagePath mapping', async () => {
       // Create test manifests
       const extManifest = {
         id: 'test-ext',
@@ -627,10 +627,10 @@ describe('FilesystemManifestWriter', () => {
 
       writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(extManifest));
 
-      // Create task in deeply nested subdirectory
-      mkdirSync(join(testDir, 'build', 'dist', 'tasks', 'installer', 'v3'), { recursive: true });
+      // Create task in subdirectory (1 level deep under contribution)
+      mkdirSync(join(testDir, 'build', 'dist', 'tasks', 'v3'), { recursive: true });
       writeFileSync(
-        join(testDir, 'build', 'dist', 'tasks', 'installer', 'v3', 'task.json'),
+        join(testDir, 'build', 'dist', 'tasks', 'v3', 'task.json'),
         JSON.stringify({
           id: 'installer-v3',
           name: 'Installer-v3',
@@ -646,18 +646,15 @@ describe('FilesystemManifestWriter', () => {
       const editor = ManifestEditor.fromReader(reader);
 
       // Update task version
-      const task = await reader.readTaskManifest('MyTasks/installer/v3');
-      await editor.updateTaskVersion(task.name, '5.0.0', 'major');
+      const task = await reader.readTaskManifest('MyTasks/v3');
+      await editor.updateTaskVersion('MyTasks/v3', '5.0.0', 'major');
 
       const writer = await editor.toWriter();
       await writer.writeToFilesystem();
 
-      // Verify file was written to build/dist/tasks/installer/v3/task.json
+      // Verify file was written to build/dist/tasks/v3/task.json
       const taskJson = JSON.parse(
-        readFileSync(
-          join(testDir, 'build', 'dist', 'tasks', 'installer', 'v3', 'task.json'),
-          'utf-8'
-        )
+        readFileSync(join(testDir, 'build', 'dist', 'tasks', 'v3', 'task.json'), 'utf-8')
       );
       expect(taskJson.version.Major).toBe(5);
       expect(taskJson.version.Minor).toBe(0);
@@ -724,10 +721,10 @@ describe('FilesystemManifestWriter', () => {
 
       // Update both tasks
       const task1 = await reader.readTaskManifest('Task1/v2');
-      await editor.updateTaskVersion(task1.name, '3.0.0', 'major');
+      await editor.updateTaskVersion('Task1/v2', '3.0.0', 'major');
 
       const task2 = await reader.readTaskManifest('Task2/v3');
-      await editor.updateTaskVersion(task2.name, '4.0.0', 'major');
+      await editor.updateTaskVersion('Task2/v3', '4.0.0', 'major');
 
       const writer = await editor.toWriter();
       await writer.writeToFilesystem();
@@ -753,19 +750,38 @@ describe('FilesystemManifestWriter', () => {
         id: 'test-ext',
         publisher: 'test-pub',
         version: '1.0.0',
-        files: [{ path: 'compiled/task', packagePath: 'Task' }],
+        files: [
+          { path: 'compiled/task', packagePath: 'Task' },
+          { path: 'TaskOther' },
+        ],
         contributions: [
           {
             id: 'task1',
             type: 'ms.vss-distributed-task.task',
             properties: { name: 'Task' },
           },
+          {
+            id: 'task2',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'TaskOther' },
+          },
         ],
       };
 
       writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(extManifest));
 
-      // Create TaskOther without packagePath mapping
+      // Create Task at compiled/task (with packagePath mapping)
+      mkdirSync(join(testDir, 'compiled', 'task'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'compiled', 'task', 'task.json'),
+        JSON.stringify({
+          id: 'task-main',
+          name: 'Task',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+
+      // Create TaskOther at its direct path (no packagePath mapping)
       mkdirSync(join(testDir, 'TaskOther'), { recursive: true });
       writeFileSync(
         join(testDir, 'TaskOther', 'task.json'),
@@ -785,7 +801,7 @@ describe('FilesystemManifestWriter', () => {
 
       // Update TaskOther
       const task = await reader.readTaskManifest('TaskOther');
-      await editor.updateTaskVersion(task.name, '2.0.0', 'major');
+      await editor.updateTaskVersion('TaskOther', '2.0.0', 'major');
 
       const writer = await editor.toWriter();
       await writer.writeToFilesystem();
@@ -857,10 +873,10 @@ describe('FilesystemManifestWriter', () => {
 
       // Update both tasks
       const taskCLI = await reader.readTaskManifest('CLI/v2');
-      await editor.updateTaskVersion(taskCLI.name, '3.0.0', 'major');
+      await editor.updateTaskVersion('CLI/v2', '3.0.0', 'major');
 
       const taskCLIUtils = await reader.readTaskManifest('CLIUtils/v2');
-      await editor.updateTaskVersion(taskCLIUtils.name, '4.0.0', 'major');
+      await editor.updateTaskVersion('CLIUtils/v2', '4.0.0', 'major');
 
       const writer = await editor.toWriter();
       await writer.writeToFilesystem();
@@ -876,6 +892,409 @@ describe('FilesystemManifestWriter', () => {
         readFileSync(join(testDir, 'build', 'cli-utils', 'v2', 'task.json'), 'utf-8')
       );
       expect(cliUtilsJson.version.Major).toBe(4);
+
+      await writer.close();
+      await reader.close();
+    });
+
+    it('should write multi-version task manifests discovered via findTaskPaths', async () => {
+      const extManifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'MyTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(extManifest));
+
+      mkdirSync(join(testDir, 'MyTask', 'v1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v1', 'task.json'),
+        JSON.stringify({
+          id: 'id-v1',
+          name: 'MyTask',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+      mkdirSync(join(testDir, 'MyTask', 'v2'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v2', 'task.json'),
+        JSON.stringify({
+          id: 'id-v2',
+          name: 'MyTaskV2',
+          version: { Major: 2, Minor: 0, Patch: 0 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const editor = ManifestEditor.fromReader(reader);
+
+      // Update both versions by path
+      await editor.updateTaskVersion('MyTask/v1', '5.0.0', 'major');
+      await editor.updateTaskVersion('MyTask/v2', '5.0.0', 'major');
+
+      const writer = await editor.toWriter();
+      await writer.writeToFilesystem();
+
+      const v1Json = JSON.parse(
+        readFileSync(join(testDir, 'MyTask', 'v1', 'task.json'), 'utf-8')
+      );
+      expect(v1Json.version.Major).toBe(5);
+      expect(v1Json.version.Minor).toBe(0);
+      expect(v1Json.version.Patch).toBe(0);
+      expect(v1Json.name).toBe('MyTask');
+
+      const v2Json = JSON.parse(
+        readFileSync(join(testDir, 'MyTask', 'v2', 'task.json'), 'utf-8')
+      );
+      expect(v2Json.version.Major).toBe(5);
+      expect(v2Json.version.Minor).toBe(0);
+      expect(v2Json.version.Patch).toBe(0);
+      expect(v2Json.name).toBe('MyTaskV2');
+
+      await writer.close();
+      await reader.close();
+    });
+
+    it('should write multi-version tasks with packagePath mapping', async () => {
+      const extManifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        files: [{ path: 'compiled/cli', packagePath: 'CLI' }],
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'CLI' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(extManifest));
+
+      mkdirSync(join(testDir, 'compiled', 'cli', 'v1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'compiled', 'cli', 'v1', 'task.json'),
+        JSON.stringify({
+          id: 'cli-v1',
+          name: 'CLI-v1',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+      mkdirSync(join(testDir, 'compiled', 'cli', 'v2'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'compiled', 'cli', 'v2', 'task.json'),
+        JSON.stringify({
+          id: 'cli-v2',
+          name: 'CLI-v2',
+          version: { Major: 2, Minor: 0, Patch: 0 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const editor = ManifestEditor.fromReader(reader);
+      await editor.updateTaskVersion('CLI/v1', '3.0.0', 'major');
+      await editor.updateTaskVersion('CLI/v2', '3.0.0', 'major');
+
+      const writer = await editor.toWriter();
+      await writer.writeToFilesystem();
+
+      // CLI/v1 → compiled/cli/v1
+      const v1Json = JSON.parse(
+        readFileSync(join(testDir, 'compiled', 'cli', 'v1', 'task.json'), 'utf-8')
+      );
+      expect(v1Json.version.Major).toBe(3);
+      expect(v1Json.name).toBe('CLI-v1');
+
+      // CLI/v2 → compiled/cli/v2
+      const v2Json = JSON.parse(
+        readFileSync(join(testDir, 'compiled', 'cli', 'v2', 'task.json'), 'utf-8')
+      );
+      expect(v2Json.version.Major).toBe(3);
+      expect(v2Json.name).toBe('CLI-v2');
+
+      await writer.close();
+      await reader.close();
+    });
+
+    it('should update multi-version tasks via applyOptions', async () => {
+      const extManifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'MyTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(extManifest));
+
+      mkdirSync(join(testDir, 'MyTask', 'v1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v1', 'task.json'),
+        JSON.stringify({
+          id: 'id-v1',
+          name: 'MyTask',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+      mkdirSync(join(testDir, 'MyTask', 'v2'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v2', 'task.json'),
+        JSON.stringify({
+          id: 'id-v2',
+          name: 'MyTaskV2',
+          version: { Major: 2, Minor: 0, Patch: 0 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const editor = ManifestEditor.fromReader(reader);
+      await editor.applyOptions({
+        extensionVersion: '4.1.2',
+        updateTasksVersion: 'major',
+        updateTasksId: true,
+      });
+
+      const writer = await editor.toWriter();
+      await writer.writeToFilesystem();
+
+      const v1Json = JSON.parse(
+        readFileSync(join(testDir, 'MyTask', 'v1', 'task.json'), 'utf-8')
+      );
+      expect(v1Json.version.Major).toBe(4);
+      expect(v1Json.version.Minor).toBe(1);
+      expect(v1Json.version.Patch).toBe(2);
+      // ID should be updated (deterministic UUID)
+      expect(v1Json.id).not.toBe('id-v1');
+
+      const v2Json = JSON.parse(
+        readFileSync(join(testDir, 'MyTask', 'v2', 'task.json'), 'utf-8')
+      );
+      expect(v2Json.version.Major).toBe(4);
+      expect(v2Json.version.Minor).toBe(1);
+      expect(v2Json.version.Patch).toBe(2);
+      expect(v2Json.id).not.toBe('id-v2');
+
+      await writer.close();
+      await reader.close();
+    });
+
+    it('should generate different task IDs for multi-version tasks with different names', async () => {
+      const extManifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'MyTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(extManifest));
+
+      mkdirSync(join(testDir, 'MyTask', 'v1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v1', 'task.json'),
+        JSON.stringify({
+          id: 'original-v1',
+          name: 'MyTask',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+      mkdirSync(join(testDir, 'MyTask', 'v2'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v2', 'task.json'),
+        JSON.stringify({
+          id: 'original-v2',
+          name: 'MyTaskV2',
+          version: { Major: 2, Minor: 0, Patch: 0 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const editor = ManifestEditor.fromReader(reader);
+      await editor.applyOptions({
+        updateTasksId: true,
+      });
+
+      const writer = await editor.toWriter();
+      await writer.writeToFilesystem();
+
+      const v1Json = JSON.parse(
+        readFileSync(join(testDir, 'MyTask', 'v1', 'task.json'), 'utf-8')
+      );
+      const v2Json = JSON.parse(
+        readFileSync(join(testDir, 'MyTask', 'v2', 'task.json'), 'utf-8')
+      );
+
+      // Different task names should produce different UUIDs
+      expect(v1Json.id).not.toBe(v2Json.id);
+      // Both should be different from originals
+      expect(v1Json.id).not.toBe('original-v1');
+      expect(v2Json.id).not.toBe('original-v2');
+
+      await writer.close();
+      await reader.close();
+    });
+
+    it('should generate same task ID for multi-version tasks with same name', async () => {
+      const extManifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'MyTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(extManifest));
+
+      mkdirSync(join(testDir, 'MyTask', 'v1'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v1', 'task.json'),
+        JSON.stringify({
+          id: 'original-v1',
+          name: 'MyTask',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+      mkdirSync(join(testDir, 'MyTask', 'v2'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'MyTask', 'v2', 'task.json'),
+        JSON.stringify({
+          id: 'original-v2',
+          name: 'MyTask',
+          version: { Major: 2, Minor: 0, Patch: 0 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const editor = ManifestEditor.fromReader(reader);
+      await editor.applyOptions({
+        updateTasksId: true,
+      });
+
+      const writer = await editor.toWriter();
+      await writer.writeToFilesystem();
+
+      const v1Json = JSON.parse(
+        readFileSync(join(testDir, 'MyTask', 'v1', 'task.json'), 'utf-8')
+      );
+      const v2Json = JSON.parse(
+        readFileSync(join(testDir, 'MyTask', 'v2', 'task.json'), 'utf-8')
+      );
+
+      // Same task name should produce the same UUID
+      expect(v1Json.id).toBe(v2Json.id);
+
+      await writer.close();
+      await reader.close();
+    });
+
+    it('should write multi-version tasks with per-version packagePath mappings', async () => {
+      const extManifest = {
+        id: 'test-ext',
+        publisher: 'test-pub',
+        version: '1.0.0',
+        files: [
+          { path: 'build/legacy', packagePath: 'MyTask/v1' },
+          { path: 'dist/current', packagePath: 'MyTask/v2' },
+        ],
+        contributions: [
+          {
+            id: 'task1',
+            type: 'ms.vss-distributed-task.task',
+            properties: { name: 'MyTask' },
+          },
+        ],
+      };
+
+      writeFileSync(join(testDir, 'vss-extension.json'), JSON.stringify(extManifest));
+
+      // Each version from a separate source directory
+      mkdirSync(join(testDir, 'build', 'legacy'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'build', 'legacy', 'task.json'),
+        JSON.stringify({
+          id: 'task-v1',
+          name: 'MyTask',
+          version: { Major: 1, Minor: 0, Patch: 0 },
+        })
+      );
+      mkdirSync(join(testDir, 'dist', 'current'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'dist', 'current', 'task.json'),
+        JSON.stringify({
+          id: 'task-v2',
+          name: 'MyTask',
+          version: { Major: 2, Minor: 0, Patch: 0 },
+        })
+      );
+
+      const reader = new FilesystemManifestReader({
+        rootFolder: testDir,
+        platform: mockPlatform,
+      });
+
+      const editor = ManifestEditor.fromReader(reader);
+      await editor.updateTaskVersion('MyTask/v1', '5.0.0', 'major');
+      await editor.updateTaskVersion('MyTask/v2', '5.0.0', 'major');
+
+      const writer = await editor.toWriter();
+      await writer.writeToFilesystem();
+
+      // MyTask/v1 → build/legacy
+      const v1Json = JSON.parse(
+        readFileSync(join(testDir, 'build', 'legacy', 'task.json'), 'utf-8')
+      );
+      expect(v1Json.version.Major).toBe(5);
+      expect(v1Json.name).toBe('MyTask');
+
+      // MyTask/v2 → dist/current
+      const v2Json = JSON.parse(
+        readFileSync(join(testDir, 'dist', 'current', 'task.json'), 'utf-8')
+      );
+      expect(v2Json.version.Major).toBe(5);
+      expect(v2Json.name).toBe('MyTask');
 
       await writer.close();
       await reader.close();

--- a/packages/core/src/__tests__/filesystem-manifest-writer.test.ts
+++ b/packages/core/src/__tests__/filesystem-manifest-writer.test.ts
@@ -720,10 +720,7 @@ describe('FilesystemManifestWriter', () => {
       const editor = ManifestEditor.fromReader(reader);
 
       // Update both tasks
-      const task1 = await reader.readTaskManifest('Task1/v2');
       await editor.updateTaskVersion('Task1/v2', '3.0.0', 'major');
-
-      const task2 = await reader.readTaskManifest('Task2/v3');
       await editor.updateTaskVersion('Task2/v3', '4.0.0', 'major');
 
       const writer = await editor.toWriter();
@@ -869,10 +866,7 @@ describe('FilesystemManifestWriter', () => {
       const editor = ManifestEditor.fromReader(reader);
 
       // Update both tasks
-      const taskCLI = await reader.readTaskManifest('CLI/v2');
       await editor.updateTaskVersion('CLI/v2', '3.0.0', 'major');
-
-      const taskCLIUtils = await reader.readTaskManifest('CLIUtils/v2');
       await editor.updateTaskVersion('CLIUtils/v2', '4.0.0', 'major');
 
       const writer = await editor.toWriter();

--- a/packages/core/src/__tests__/filesystem-manifest-writer.test.ts
+++ b/packages/core/src/__tests__/filesystem-manifest-writer.test.ts
@@ -750,10 +750,7 @@ describe('FilesystemManifestWriter', () => {
         id: 'test-ext',
         publisher: 'test-pub',
         version: '1.0.0',
-        files: [
-          { path: 'compiled/task', packagePath: 'Task' },
-          { path: 'TaskOther' },
-        ],
+        files: [{ path: 'compiled/task', packagePath: 'Task' }, { path: 'TaskOther' }],
         contributions: [
           {
             id: 'task1',
@@ -946,17 +943,13 @@ describe('FilesystemManifestWriter', () => {
       const writer = await editor.toWriter();
       await writer.writeToFilesystem();
 
-      const v1Json = JSON.parse(
-        readFileSync(join(testDir, 'MyTask', 'v1', 'task.json'), 'utf-8')
-      );
+      const v1Json = JSON.parse(readFileSync(join(testDir, 'MyTask', 'v1', 'task.json'), 'utf-8'));
       expect(v1Json.version.Major).toBe(5);
       expect(v1Json.version.Minor).toBe(0);
       expect(v1Json.version.Patch).toBe(0);
       expect(v1Json.name).toBe('MyTask');
 
-      const v2Json = JSON.parse(
-        readFileSync(join(testDir, 'MyTask', 'v2', 'task.json'), 'utf-8')
-      );
+      const v2Json = JSON.parse(readFileSync(join(testDir, 'MyTask', 'v2', 'task.json'), 'utf-8'));
       expect(v2Json.version.Major).toBe(5);
       expect(v2Json.version.Minor).toBe(0);
       expect(v2Json.version.Patch).toBe(0);
@@ -1082,18 +1075,14 @@ describe('FilesystemManifestWriter', () => {
       const writer = await editor.toWriter();
       await writer.writeToFilesystem();
 
-      const v1Json = JSON.parse(
-        readFileSync(join(testDir, 'MyTask', 'v1', 'task.json'), 'utf-8')
-      );
+      const v1Json = JSON.parse(readFileSync(join(testDir, 'MyTask', 'v1', 'task.json'), 'utf-8'));
       expect(v1Json.version.Major).toBe(4);
       expect(v1Json.version.Minor).toBe(1);
       expect(v1Json.version.Patch).toBe(2);
       // ID should be updated (deterministic UUID)
       expect(v1Json.id).not.toBe('id-v1');
 
-      const v2Json = JSON.parse(
-        readFileSync(join(testDir, 'MyTask', 'v2', 'task.json'), 'utf-8')
-      );
+      const v2Json = JSON.parse(readFileSync(join(testDir, 'MyTask', 'v2', 'task.json'), 'utf-8'));
       expect(v2Json.version.Major).toBe(4);
       expect(v2Json.version.Minor).toBe(1);
       expect(v2Json.version.Patch).toBe(2);
@@ -1151,12 +1140,8 @@ describe('FilesystemManifestWriter', () => {
       const writer = await editor.toWriter();
       await writer.writeToFilesystem();
 
-      const v1Json = JSON.parse(
-        readFileSync(join(testDir, 'MyTask', 'v1', 'task.json'), 'utf-8')
-      );
-      const v2Json = JSON.parse(
-        readFileSync(join(testDir, 'MyTask', 'v2', 'task.json'), 'utf-8')
-      );
+      const v1Json = JSON.parse(readFileSync(join(testDir, 'MyTask', 'v1', 'task.json'), 'utf-8'));
+      const v2Json = JSON.parse(readFileSync(join(testDir, 'MyTask', 'v2', 'task.json'), 'utf-8'));
 
       // Different task names should produce different UUIDs
       expect(v1Json.id).not.toBe(v2Json.id);
@@ -1216,12 +1201,8 @@ describe('FilesystemManifestWriter', () => {
       const writer = await editor.toWriter();
       await writer.writeToFilesystem();
 
-      const v1Json = JSON.parse(
-        readFileSync(join(testDir, 'MyTask', 'v1', 'task.json'), 'utf-8')
-      );
-      const v2Json = JSON.parse(
-        readFileSync(join(testDir, 'MyTask', 'v2', 'task.json'), 'utf-8')
-      );
+      const v1Json = JSON.parse(readFileSync(join(testDir, 'MyTask', 'v1', 'task.json'), 'utf-8'));
+      const v2Json = JSON.parse(readFileSync(join(testDir, 'MyTask', 'v2', 'task.json'), 'utf-8'));
 
       // Same task name should produce the same UUID
       expect(v1Json.id).toBe(v2Json.id);

--- a/packages/core/src/__tests__/vsix-editor-writer.test.ts
+++ b/packages/core/src/__tests__/vsix-editor-writer.test.ts
@@ -181,7 +181,7 @@ describe('ManifestEditor', () => {
     const reader = await VsixReader.open(testVsixPath);
     const editor = ManifestEditor.fromReader(reader);
 
-    editor.updateTaskId('TestTask', 'test-publisher', 'test-extension');
+    editor.updateTaskId('TestTask', 'TestTask', 'test-publisher', 'test-extension');
 
     const taskMods = editor.getTaskManifestModifications();
     expect(taskMods.get('TestTask')?.id).toBeTruthy();

--- a/packages/core/src/commands/package.ts
+++ b/packages/core/src/commands/package.ts
@@ -183,6 +183,7 @@ export async function packageExtension(
           const tasks = await reader.getTasksInfo();
           for (const task of tasks) {
             editor.updateTaskId(
+              task.path,
               task.name,
               resolvedTaskUpdateOptions.publisherId,
               resolvedTaskUpdateOptions.extensionId

--- a/packages/core/src/commands/publish.ts
+++ b/packages/core/src/commands/publish.ts
@@ -328,6 +328,7 @@ export async function publishExtension(
             const tasks = await reader.getTasksInfo();
             for (const task of tasks) {
               editor.updateTaskId(
+                task.path,
                 task.name,
                 resolvedTaskUpdateOptions.publisherId,
                 resolvedTaskUpdateOptions.extensionId

--- a/packages/core/src/filesystem-manifest-reader.ts
+++ b/packages/core/src/filesystem-manifest-reader.ts
@@ -182,7 +182,14 @@ export class FilesystemManifestReader extends ManifestReader {
                 // Multi-version via per-version packagePath mappings
                 // (e.g., MyTask/v1 → build/legacy, MyTask/v2 → dist/current)
                 const prefixMatches = await this.findPackagePathPrefixMatches(name, packagePathMap);
-                taskPaths.push(...prefixMatches);
+                if (prefixMatches.length > 0) {
+                  taskPaths.push(...prefixMatches);
+                } else {
+                  this.platform.warning(
+                    `No task.json found for contribution '${name}'. ` +
+                      `Searched '${actualPath}' and its immediate subdirectories.`
+                  );
+                }
               }
             }
           }

--- a/packages/core/src/filesystem-manifest-reader.ts
+++ b/packages/core/src/filesystem-manifest-reader.ts
@@ -5,7 +5,7 @@
  * and task manifests directly from source directories.
  */
 
-import { readFile } from 'fs/promises';
+import { readFile, readdir } from 'fs/promises';
 import path from 'path';
 import { ManifestReader, type ExtensionManifest, type TaskManifest } from './manifest-reader.js';
 import type { IPlatformAdapter } from './platform.js';
@@ -140,11 +140,14 @@ export class FilesystemManifestReader extends ManifestReader {
 
   /**
    * Find task paths from the extension manifest
+   * Supports both single-version tasks (task.json directly in the contribution folder)
+   * and multi-version tasks (task.json in subdirectories like v1/, v2/, v3/).
    * @returns Array of task directory paths (relative to rootFolder)
    */
   async findTaskPaths(): Promise<string[]> {
     const manifest = await this.readExtensionManifest();
     const taskPaths: string[] = [];
+    const packagePathMap = await this.buildPackagePathMap();
 
     // Look for task contributions
     if (manifest.contributions) {
@@ -152,7 +155,39 @@ export class FilesystemManifestReader extends ManifestReader {
         if (contribution.type === 'ms.vss-distributed-task.task' && contribution.properties) {
           const name = contribution.properties.name as string;
           if (name) {
-            taskPaths.push(name);
+            // Resolve contribution name to actual filesystem path
+            let actualPath = name;
+            for (const [pkgPath, sourcePath] of packagePathMap.entries()) {
+              if (name === pkgPath) {
+                actualPath = sourcePath;
+                break;
+              }
+            }
+
+            const absolutePath = path.isAbsolute(actualPath)
+              ? actualPath
+              : path.join(this.rootFolder, actualPath);
+
+            const taskJsonPath = path.join(absolutePath, 'task.json');
+
+            if (await this.platform.fileExists(taskJsonPath)) {
+              // Single-version task: task.json directly in the contribution folder
+              taskPaths.push(name);
+            } else {
+              // Multi-version task: scan subdirectories for task.json
+              const expanded = await this.findMultiVersionTaskPaths(absolutePath, name);
+              if (expanded.length > 0) {
+                taskPaths.push(...expanded);
+              } else {
+                // Multi-version via per-version packagePath mappings
+                // (e.g., MyTask/v1 → build/legacy, MyTask/v2 → dist/current)
+                const prefixMatches = await this.findPackagePathPrefixMatches(
+                  name,
+                  packagePathMap
+                );
+                taskPaths.push(...prefixMatches);
+              }
+            }
           }
         }
       }
@@ -169,6 +204,80 @@ export class FilesystemManifestReader extends ManifestReader {
     }
 
     return taskPaths;
+  }
+
+  /**
+   * Find task.json files in subdirectories of a multi-version task contribution.
+   * Multi-version tasks have subdirectories (e.g., v1/, v2/, v3/) each containing
+   * their own task.json. Subdirectories without task.json are ignored.
+   * @param absoluteBasePath Absolute path to the contribution folder on disk
+   * @param contributionName The contribution name (used as path prefix in results)
+   * @returns Array of expanded task paths (e.g., ['MyTask/v1', 'MyTask/v2'])
+   */
+  private async findMultiVersionTaskPaths(
+    absoluteBasePath: string,
+    contributionName: string
+  ): Promise<string[]> {
+    const taskPaths: string[] = [];
+
+    try {
+      const entries = await readdir(absoluteBasePath, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          const subTaskJsonPath = path.join(absoluteBasePath, entry.name, 'task.json');
+          if (await this.platform.fileExists(subTaskJsonPath)) {
+            taskPaths.push(`${contributionName}/${entry.name}`);
+          }
+        }
+      }
+    } catch {
+      // Directory doesn't exist or can't be read
+    }
+
+    if (taskPaths.length > 0) {
+      this.platform.debug(
+        `Found multi-version task '${contributionName}' with ${taskPaths.length} version(s): ${taskPaths.join(', ')}`
+      );
+    }
+
+    return taskPaths;
+  }
+
+  /**
+   * Find task paths from packagePath entries that are prefixed with the contribution name.
+   * Handles cases where each version is mapped from a separate source directory
+   * (e.g., MyTask/v1 → build/legacy, MyTask/v2 → dist/current).
+   * Only includes entries whose mapped source paths actually contain a task.json.
+   * @param contributionName The contribution name to match as prefix
+   * @param packagePathMap Map of packagePath to source path
+   * @returns Array of packagePath entries that matched (e.g., ['MyTask/v1', 'MyTask/v2'])
+   */
+  private async findPackagePathPrefixMatches(
+    contributionName: string,
+    packagePathMap: Map<string, string>
+  ): Promise<string[]> {
+    const prefix = contributionName + '/';
+    const matches: string[] = [];
+
+    for (const [pkgPath, sourcePath] of packagePathMap.entries()) {
+      if (pkgPath.startsWith(prefix)) {
+        const absoluteSourcePath = path.isAbsolute(sourcePath)
+          ? sourcePath
+          : path.join(this.rootFolder, sourcePath);
+        const taskJsonPath = path.join(absoluteSourcePath, 'task.json');
+        if (await this.platform.fileExists(taskJsonPath)) {
+          matches.push(pkgPath);
+        }
+      }
+    }
+
+    if (matches.length > 0) {
+      this.platform.debug(
+        `Found multi-version task '${contributionName}' via packagePath mappings: ${matches.join(', ')}`
+      );
+    }
+
+    return matches;
   }
 
   /**

--- a/packages/core/src/filesystem-manifest-reader.ts
+++ b/packages/core/src/filesystem-manifest-reader.ts
@@ -181,10 +181,7 @@ export class FilesystemManifestReader extends ManifestReader {
               } else {
                 // Multi-version via per-version packagePath mappings
                 // (e.g., MyTask/v1 → build/legacy, MyTask/v2 → dist/current)
-                const prefixMatches = await this.findPackagePathPrefixMatches(
-                  name,
-                  packagePathMap
-                );
+                const prefixMatches = await this.findPackagePathPrefixMatches(name, packagePathMap);
                 taskPaths.push(...prefixMatches);
               }
             }

--- a/packages/core/src/filesystem-manifest-writer.ts
+++ b/packages/core/src/filesystem-manifest-writer.ts
@@ -126,15 +126,13 @@ export class FilesystemManifestWriter {
     taskManifestMods: Map<string, Partial<TaskManifest>>
   ): Promise<void> {
     const tasks = await reader.readTaskManifests();
-    const appliedTaskNames = new Set<string>();
 
     // Get packagePath map to resolve actual source paths
     const packagePathMap = (await (reader as any).buildPackagePathMap()) as Map<string, string>;
 
     for (const { path: taskPath, manifest } of tasks) {
-      const mods = taskManifestMods.get(manifest.name);
+      const mods = taskManifestMods.get(taskPath);
       if (mods) {
-        appliedTaskNames.add(manifest.name);
         // Apply modifications
         Object.assign(manifest, mods);
 
@@ -175,73 +173,6 @@ export class FilesystemManifestWriter {
         await writeFile(taskJsonPath, manifestJson, 'utf-8');
       }
     }
-
-    // Fallback: apply modifications for tasks not discoverable via contribution paths
-    for (const [taskName, mods] of taskManifestMods.entries()) {
-      if (appliedTaskNames.has(taskName)) {
-        continue;
-      }
-
-      const fallbackTaskDir = await this.findTaskDirectoryByName(rootFolder, taskName);
-      if (!fallbackTaskDir) {
-        this.platform.debug(`No task.json found for task '${taskName}' during fallback write`);
-        continue;
-      }
-
-      const taskJsonPath = path.join(fallbackTaskDir, 'task.json');
-      const content = (await readFile(taskJsonPath)).toString('utf8');
-      const manifest = JSON.parse(content) as TaskManifest;
-      Object.assign(manifest, mods);
-
-      this.platform.debug(`Fallback writing task manifest: ${taskJsonPath}`);
-      await writeFile(taskJsonPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
-    }
-  }
-
-  /**
-   * Recursively find a task directory by task manifest name
-   */
-  private async findTaskDirectoryByName(
-    rootFolder: string,
-    taskName: string
-  ): Promise<string | null> {
-    const stack: string[] = [rootFolder];
-
-    while (stack.length > 0) {
-      const current = stack.pop();
-      let entries;
-
-      try {
-        entries = await readdir(current, { withFileTypes: true });
-      } catch {
-        continue;
-      }
-
-      for (const entry of entries) {
-        const absolutePath = path.join(current, entry.name);
-
-        if (entry.isDirectory()) {
-          stack.push(absolutePath);
-          continue;
-        }
-
-        if (!entry.isFile() || entry.name !== 'task.json') {
-          continue;
-        }
-
-        try {
-          const content = (await readFile(absolutePath)).toString('utf8');
-          const manifest = JSON.parse(content) as TaskManifest;
-          if (manifest.name === taskName) {
-            return path.dirname(absolutePath);
-          }
-        } catch {
-          // ignore unreadable/invalid task manifests during search
-        }
-      }
-    }
-
-    return null;
   }
 
   /**

--- a/packages/core/src/manifest-editor.ts
+++ b/packages/core/src/manifest-editor.ts
@@ -275,13 +275,13 @@ export class ManifestEditor {
 
   /**
    * Update a specific task's version
-   * @param taskName Name of the task
+   * @param taskPath Path to the task (used as modification key)
    * @param extensionVersion Extension version to apply (e.g., "1.2.3")
    * @param versionType How to apply the version: 'major', 'minor', or 'patch'
    * @returns This editor for chaining
    */
   updateTaskVersion(
-    taskName: string,
+    taskPath: string,
     extensionVersion: string,
     versionType: 'major' | 'minor' | 'patch' = 'major'
   ): this {
@@ -297,11 +297,11 @@ export class ManifestEditor {
       patch: parseInt(versionParts[2], 10) || 0,
     };
 
-    if (!this.taskManifestModifications.has(taskName)) {
-      this.taskManifestModifications.set(taskName, {});
+    if (!this.taskManifestModifications.has(taskPath)) {
+      this.taskManifestModifications.set(taskPath, {});
     }
 
-    const taskMods = this.taskManifestModifications.get(taskName);
+    const taskMods = this.taskManifestModifications.get(taskPath);
 
     // Get existing version from modifications or we'll read it when applying
     const existingVersion = taskMods.version || { Major: 0, Minor: 0, Patch: 0 };
@@ -336,23 +336,29 @@ export class ManifestEditor {
 
   /**
    * Update a specific task's ID (UUID) using v5 namespacing
-   * @param taskName Name of the task
+   * @param taskPath Path to the task (used as modification key)
+   * @param taskName Name of the task (used for deterministic UUID generation)
    * @param publisherId Publisher ID (for UUID generation)
    * @param extensionId Extension ID (for UUID generation)
    * @returns This editor for chaining
    */
-  updateTaskId(taskName: string, publisherId: string, extensionId: string): this {
+  updateTaskId(
+    taskPath: string,
+    taskName: string,
+    publisherId: string,
+    extensionId: string
+  ): this {
     // Generate deterministic UUID v5 based on publisher, extension, and task name
     // This matches v5 implementation exactly
     const marketplaceNamespace = uuidv5('https://marketplace.visualstudio.com/vsts', uuidv5.URL);
     const taskNamespace = `${publisherId}.${extensionId}.${taskName}`;
     const newId = uuidv5(taskNamespace, marketplaceNamespace);
 
-    if (!this.taskManifestModifications.has(taskName)) {
-      this.taskManifestModifications.set(taskName, {});
+    if (!this.taskManifestModifications.has(taskPath)) {
+      this.taskManifestModifications.set(taskPath, {});
     }
 
-    const taskMods = this.taskManifestModifications.get(taskName);
+    const taskMods = this.taskManifestModifications.get(taskPath);
 
     // Store old ID for updating extension manifest references later
     // We'll read the old ID when applying modifications
@@ -388,11 +394,11 @@ export class ManifestEditor {
         Patch: parseInt(existingParts[2], 10) || 0,
       };
 
-      if (!this.taskManifestModifications.has(task.name)) {
-        this.taskManifestModifications.set(task.name, {});
+      if (!this.taskManifestModifications.has(task.path)) {
+        this.taskManifestModifications.set(task.path, {});
       }
 
-      const taskMods = this.taskManifestModifications.get(task.name);
+      const taskMods = this.taskManifestModifications.get(task.path);
 
       switch (versionType) {
         case 'major':
@@ -435,7 +441,7 @@ export class ManifestEditor {
     const tasks = await this.reader.getTasksInfo();
 
     for (const task of tasks) {
-      this.updateTaskId(task.name, publisherId, extensionId);
+      this.updateTaskId(task.path, task.name, publisherId, extensionId);
     }
 
     return this;

--- a/packages/core/src/manifest-editor.ts
+++ b/packages/core/src/manifest-editor.ts
@@ -342,12 +342,7 @@ export class ManifestEditor {
    * @param extensionId Extension ID (for UUID generation)
    * @returns This editor for chaining
    */
-  updateTaskId(
-    taskPath: string,
-    taskName: string,
-    publisherId: string,
-    extensionId: string
-  ): this {
+  updateTaskId(taskPath: string, taskName: string, publisherId: string, extensionId: string): this {
     // Generate deterministic UUID v5 based on publisher, extension, and task name
     // This matches v5 implementation exactly
     const marketplaceNamespace = uuidv5('https://marketplace.visualstudio.com/vsts', uuidv5.URL);

--- a/packages/core/src/vsix-reader.ts
+++ b/packages/core/src/vsix-reader.ts
@@ -358,10 +358,7 @@ export class VsixReader extends ManifestReader {
               // Multi-version: find subdirectories with task.json
               const prefix = `${name}/`.replace(/\\/g, '/');
               for (const entry of entries) {
-                if (
-                  entry.fileName.startsWith(prefix) &&
-                  entry.fileName.endsWith('/task.json')
-                ) {
+                if (entry.fileName.startsWith(prefix) && entry.fileName.endsWith('/task.json')) {
                   // Extract the subdirectory path (e.g., "MyTask/v1" from "MyTask/v1/task.json")
                   const taskDir = entry.fileName.slice(0, -'/task.json'.length);
                   // Only include direct subdirectories (one level deep under the contribution)

--- a/packages/core/src/vsix-reader.ts
+++ b/packages/core/src/vsix-reader.ts
@@ -334,12 +334,15 @@ export class VsixReader extends ManifestReader {
   }
 
   /**
-   * Find task directories from the extension manifest
+   * Find task directories from the extension manifest.
+   * Supports both single-version tasks (task.json directly in the contribution folder)
+   * and multi-version tasks (task.json in subdirectories like v1/, v2/, v3/).
    * @returns Array of task directory paths
    */
   async findTaskPaths(): Promise<string[]> {
     const manifest = await this.readExtensionManifest();
     const taskPathsSet = new Set<string>();
+    const entries = await this.readEntries();
 
     // Look for task contributions
     if (manifest.contributions) {
@@ -347,7 +350,28 @@ export class VsixReader extends ManifestReader {
         if (contribution.type === 'ms.vss-distributed-task.task' && contribution.properties) {
           const name = contribution.properties.name as string;
           if (name) {
-            taskPathsSet.add(name);
+            const directTaskJson = `${name}/task.json`.replace(/\\/g, '/');
+            if (entries.some((e) => e.fileName === directTaskJson)) {
+              // Single-version: task.json directly in the contribution folder
+              taskPathsSet.add(name);
+            } else {
+              // Multi-version: find subdirectories with task.json
+              const prefix = `${name}/`.replace(/\\/g, '/');
+              for (const entry of entries) {
+                if (
+                  entry.fileName.startsWith(prefix) &&
+                  entry.fileName.endsWith('/task.json')
+                ) {
+                  // Extract the subdirectory path (e.g., "MyTask/v1" from "MyTask/v1/task.json")
+                  const taskDir = entry.fileName.slice(0, -'/task.json'.length);
+                  // Only include direct subdirectories (one level deep under the contribution)
+                  const remainder = taskDir.slice(prefix.length);
+                  if (remainder && !remainder.includes('/')) {
+                    taskPathsSet.add(taskDir);
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -355,7 +379,6 @@ export class VsixReader extends ManifestReader {
 
     // Look for files array (only if no contributions found)
     if (taskPathsSet.size === 0 && manifest.files) {
-      const entries = await this.readEntries();
       for (const file of manifest.files) {
         // Task directories typically contain task.json
         const taskJsonPath = `${file.path}/task.json`.replace(/\\/g, '/');

--- a/packages/core/src/vsix-writer.ts
+++ b/packages/core/src/vsix-writer.ts
@@ -364,7 +364,7 @@ export class VsixWriter {
       const taskManifests = await reader.readTaskManifests();
 
       for (const taskManifest of taskManifests) {
-        const mods = taskManifestMods.get(taskManifest.manifest.name);
+        const mods = taskManifestMods.get(taskManifest.path);
         if (mods) {
           // Apply modifications to the manifest object
           Object.assign(taskManifest.manifest, mods);


### PR DESCRIPTION
- Changed task version update method to use task path instead of task name for better accuracy.
- Updated task ID generation to include task path as a parameter for deterministic UUID generation.
- Enhanced task path discovery in filesystem and VSIX readers to support multi-version tasks.
- Removed fallback logic for task modifications, relying on direct task path mapping.
- Improved test coverage for multi-version task handling in filesystem manifest writer.

This pull request refactors how task manifest modifications are tracked and applied, improving support for multi-version tasks and ensuring more reliable updates when packaging and publishing extensions. The changes unify the use of task path (rather than task name) as the key for all task modifications, and enhance the logic for discovering both single-version and multi-version tasks in source folders and VSIX packages.

Key changes include:

**Task manifest modification tracking:**

* The `ManifestEditor` and related writer classes now use the task's path as the key for modifications (instead of the task name), ensuring correct handling of tasks with the same name in different directories or versions. (`packages/core/src/manifest-editor.ts`, `packages/core/src/filesystem-manifest-writer.ts`, `packages/core/src/vsix-writer.ts`) [[1]](diffhunk://#diff-9955f6d57ecd39bf5bd13ab019f90b9e23f5614e98655bb8dae31038e3bebb5eL278-R284) [[2]](diffhunk://#diff-9955f6d57ecd39bf5bd13ab019f90b9e23f5614e98655bb8dae31038e3bebb5eL300-R304) [[3]](diffhunk://#diff-9955f6d57ecd39bf5bd13ab019f90b9e23f5614e98655bb8dae31038e3bebb5eL339-R356) [[4]](diffhunk://#diff-9955f6d57ecd39bf5bd13ab019f90b9e23f5614e98655bb8dae31038e3bebb5eL391-R396) [[5]](diffhunk://#diff-9955f6d57ecd39bf5bd13ab019f90b9e23f5614e98655bb8dae31038e3bebb5eL438-R439) [[6]](diffhunk://#diff-fbd31b06deb936b8775e0a75674c1c80f3e828d64361890cfc8075ee4b952f66L129-L137) [[7]](diffhunk://#diff-30a96fa4589327a6669dd8a0ee623d556d2addb2f1633040bd599fca8f66fd68L367-R367)

* All calls to `updateTaskId` and `updateTaskVersion` now pass the task path as the first argument, both in the main code and in tests. (`packages/core/src/commands/package.ts`, `packages/core/src/commands/publish.ts`, `packages/core/src/__tests__/vsix-editor-writer.test.ts`) [[1]](diffhunk://#diff-91d1972d187dbed2f678773e3479f0ccd45b73571b54261c4303c51015d1db47R186) [[2]](diffhunk://#diff-a667bdb30ada347a2c1bb746fea97399df82e01ea6983e6a27e47932b1fbc13eR331) [[3]](diffhunk://#diff-476c9efbc0a061ea3d32e6f8e0fcf8895d7feeac1ad8b76c4d96889a5cd22f2bL184-R184)

**Task discovery improvements:**

* The logic for discovering task paths in both `FilesystemManifestReader` and `VsixReader` has been enhanced to fully support multi-version tasks (tasks with subdirectories like `v1`, `v2`, etc.), as well as tasks mapped via `packagePath` entries. (`packages/core/src/filesystem-manifest-reader.ts`, `packages/core/src/vsix-reader.ts`) [[1]](diffhunk://#diff-fde238a5daf3d68c3d596ac6528bd04da686adec44125647bd14b8ce92dd54adR143-R187) [[2]](diffhunk://#diff-fde238a5daf3d68c3d596ac6528bd04da686adec44125647bd14b8ce92dd54adR206-R279) [[3]](diffhunk://#diff-7d0017d5e10eeecd0f404f967c8b1ab2cce8dd4500afcfaf3c4323444c3e1265L337-L358)

**Code cleanup and simplification:**

* The fallback logic for applying modifications by task name (including recursive directory search) has been removed from `FilesystemManifestWriter`, as all modifications are now keyed by path and reliably discovered. (`packages/core/src/filesystem-manifest-writer.ts`)

* Minor import updates to support new functionality (e.g., using `readdir` from `fs/promises`). (`packages/core/src/filesystem-manifest-reader.ts`)