### PR TITLE
Increase timeout for copilot setup steps to 120 minutes

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 120
 
     permissions:
       contents: read


### PR DESCRIPTION
This pull request makes a small change to the workflow configuration by increasing the job timeout for `copilot-setup-steps` from 20 minutes to 120 minutes. This allows more time for the job to complete, which can help prevent timeouts for longer-running tasks.