### PR TITLE
Add working-directory input for manifest-based operations and workflows

### DIFF
--- a/.github/workflows/release-test-github-actions.yml
+++ b/.github/workflows/release-test-github-actions.yml
@@ -91,6 +91,7 @@ jobs:
         uses: ./
         with:
           operation: package
+          working-directory: tests/sample-extension
           publisher-id: ${{ env.PUBLISHER_ID }}
           extension-id: ${{ env.EXTENSION_ID }}
           extension-version: ${{ steps.query.outputs.proposed-version }}

--- a/README.md
+++ b/README.md
@@ -59,13 +59,25 @@ When creating a PAT for pipeline automation, include at least the following scop
 - run: echo "VSIX: ${{ steps.publish.outputs.vsix-file }}"
 ```
 
+### Manifests in a subfolder
+
+```yaml
+- uses: jessehouwing/azdo-marketplace@v6
+  with:
+    operation: package
+    working-directory: tests/sample-extension
+    manifest-file: vss-extension.json
+```
+
+For manifest-based operations, `manifest-file` patterns are resolved from `working-directory` when specified. If `working-directory` is omitted, the current working directory is used.
+
 ### Main action inputs
 
-**General**
+#### General
 
 - `operation`: Selects which command to run (`package`, `publish`, `install`, `share`, `unshare`, `unpublish`, `show`, `query-version`, `wait-for-validation`, `wait-for-installation`).
 
-**Connection & Authentication**
+#### Connection & Authentication
 
 - `auth-type`: Chooses authentication mode (`pat`, `basic`, `oidc`) for authenticated operations.
 - `service-url`: Overrides the Azure DevOps/Marketplace endpoint for supported operations.
@@ -73,21 +85,22 @@ When creating a PAT for pipeline automation, include at least the following scop
 - `tfx-version`: Selects the `tfx-cli` source (`built-in`, `path`, or npm version spec); `built-in` uses the bundled vesion, while `path` uses `tfx` from PATH.
 - `username`: Provides the username when `auth-type` is `basic`.
 
-**Extension identity**
+#### Extension Identity
 
 - `extension-id`: Sets or overrides the extension identifier inside the publisher namespace (required for `show`, optional for `install`/`share`/`unshare`/`unpublish`/`wait-for-validation`/`query-version` when inferred from manifest or VSIX inputs).
 - `publisher-id`: Sets or overrides the extension publisher identifier (required for `show`, optional for `install`/`share`/`unshare`/`unpublish`/`wait-for-validation`/`query-version` when inferred from manifest or VSIX inputs).
 
-**Input sources**
+#### Input Sources
 
 - `manifest-file`: Points to one or more manifest files used for manifest-based operations and identity fallback in install/share/unshare/unpublish/wait-for-validation/query-version.
+- `working-directory`: Sets the base directory for manifest-based operations. `manifest-file` patterns are resolved from this directory when specified.
 - `manifest-file-js`: Points to a JS manifest module for `tfx --manifest-js`.
 - `overrides-file`: Points to an overrides JSON file merged into manifest packaging/publishing.
 - `use`: Chooses publish input source (`manifest` or `vsix`).
 - `vsix-file`: Points to a pre-built VSIX file when publishing from VSIX source.
 - `vsix-file`: Provides a VSIX file for identity/task discovery in install/share/unshare/validation flows.
 
-**Packaging options**
+#### Packaging Options
 
 - `bypass-validation`: Skips package-time validation checks.
 - `extension-name`: Overrides extension display name during package/publish.
@@ -100,35 +113,35 @@ When creating a PAT for pipeline automation, include at least the following scop
 - `update-tasks-id`: Regenerates deterministic task IDs for extension variants.
 - `update-tasks-version`: Controls task version update strategy (`none`, `major`, `minor`, `patch`).
 
-**Organization targeting**
+#### Organization Targeting
 
 - `accounts`: Provides newline-separated Azure DevOps organizations for install/share/unshare/verification operations.
 
-**Query version**
+#### Query Version Inputs
 
 - `marketplace-version-action`: Controls how the queried marketplace version is transformed (`None`, `Major`, `Minor`, `Patch`).
 - `version-source`: Specifies which version sources to consider (newline-separated); highest valid semver wins. Values: `marketplace`, `manifest`, `vsix`, or a semver literal. Defaults to `marketplace`.
 
-**Wait for validation / installation**
+#### Wait For Validation / Installation
 
 - `polling-interval-seconds`: Sets polling interval between checks.
 - `timeout-minutes`: Sets total wait time.
 
-**Wait for installation**
+#### Wait For Installation
 
 - `expected-tasks`: Provides task/version expectations to verify.
 
 ### Main action outputs
 
-**Package / publish**
+#### Package / Publish
 
 - `vsix-file`: Returns path to the generated VSIX file.
 
-**Show**
+#### Show
 
 - `metadata`: Returns extension metadata JSON.
 
-**Query version**
+#### Query Version Outputs
 
 - `current-version`: Returns the current version before any increment is applied.
 - `proposed-version`: Returns the computed version after applying the version action.
@@ -144,6 +157,7 @@ When creating a PAT for pipeline automation, include at least the following scop
   with:
     publisher-id: my-publisher
     extension-id: my-extension
+    working-directory: extension
     manifest-file: vss-extension.json
 
 - run: echo "Packaged: ${{ steps.package.outputs.vsix-file }}"
@@ -157,6 +171,7 @@ When creating a PAT for pipeline automation, include at least the following scop
     token: ${{ secrets.MARKETPLACE_TOKEN }}
     publisher-id: my-publisher
     extension-id: my-extension
+    working-directory: extension
     manifest-file: vss-extension.json
 ```
 
@@ -166,6 +181,7 @@ When creating a PAT for pipeline automation, include at least the following scop
 - uses: jessehouwing/azdo-marketplace/install@v6
   with:
     token: ${{ secrets.MARKETPLACE_TOKEN }}
+    working-directory: extension
     manifest-file: vss-extension.json
     accounts: myorg
 ```
@@ -176,6 +192,7 @@ When creating a PAT for pipeline automation, include at least the following scop
 - uses: jessehouwing/azdo-marketplace/share@v6
   with:
     token: ${{ secrets.MARKETPLACE_TOKEN }}
+    working-directory: extension
     manifest-file: vss-extension.json
     accounts: customer-org
 ```
@@ -186,6 +203,7 @@ When creating a PAT for pipeline automation, include at least the following scop
 - uses: jessehouwing/azdo-marketplace/unshare@v6
   with:
     token: ${{ secrets.MARKETPLACE_TOKEN }}
+    working-directory: extension
     manifest-file: vss-extension.json
     accounts: old-customer-org
 ```
@@ -196,6 +214,7 @@ When creating a PAT for pipeline automation, include at least the following scop
 - uses: jessehouwing/azdo-marketplace/unpublish@v6
   with:
     token: ${{ secrets.MARKETPLACE_TOKEN }}
+    working-directory: extension
     manifest-file: vss-extension.json
 ```
 
@@ -221,6 +240,8 @@ When creating a PAT for pipeline automation, include at least the following scop
     token: ${{ secrets.MARKETPLACE_TOKEN }}
     publisher-id: my-publisher
     extension-id: my-extension
+    working-directory: extension
+    manifest-file: vss-extension.json
     marketplace-version-action: Patch
 
 - run: echo "Next: ${{ steps.query.outputs.proposed-version }}"
@@ -232,6 +253,7 @@ When creating a PAT for pipeline automation, include at least the following scop
 - uses: jessehouwing/azdo-marketplace/wait-for-validation@v6
   with:
     token: ${{ secrets.MARKETPLACE_TOKEN }}
+    working-directory: extension
     manifest-file: vss-extension.json
 ```
 
@@ -244,6 +266,7 @@ When creating a PAT for pipeline automation, include at least the following scop
     publisher-id: my-publisher
     extension-id: my-extension
     accounts: myorg
+    working-directory: extension
     manifest-file: vss-extension.json
 ```
 

--- a/action.schema.yaml
+++ b/action.schema.yaml
@@ -68,6 +68,9 @@ inputs:
     items:
       type: string
 
+  working-directory:
+    type: string
+
   manifest-file-js:
     type: string
 

--- a/action.yml
+++ b/action.yml
@@ -163,7 +163,7 @@ inputs:
 
       - Defaults to `vss-extension.json` if not specified
       - Can specify multiple manifest files
-      - Patterns are relative to the current working directory
+      - Patterns are relative to `working-directory` when specified, otherwise the current working directory
       - For install/share/unpublish/unshare/wait-for-validation/query-version:
         used as fallback source for publisher-id and extension-id when not specified
 
@@ -173,6 +173,20 @@ inputs:
       manifests/dev/vss-extension.json
       manifests/prod/vss-extension.json
       ```
+    required: false
+  working-directory:
+    description: |-
+      **Working directory** used as the base path for manifest-based operations.
+
+      Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
+      Required for: none.
+      Default: current working directory
+
+      - Manifest discovery and `manifest-file` patterns are resolved from this directory
+      - Use this when your extension manifest lives in a subfolder
+      - If not specified, the current working directory is used
+
+      **Example:** `tests/sample-extension`
     required: false
   manifest-file-js:
     description: |-

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,10 +7,12 @@ This folder contains implementation and usage documentation for the v6 architect
 - [Azure Pipelines usage](./azure-pipelines.md)
   - How to use the unified `azdo-marketplace@6` task
   - All supported operations and operation-specific inputs
+  - Includes `workingDirectory` for manifest-based operations rooted in a subfolder
 - [GitHub Actions usage](./github-actions.md)
   - How to use the unified `jessehouwing/azdo-marketplace@v6` action
   - All supported operations and operation-specific inputs
   - Availability and usage of composite actions per command
+  - Includes `working-directory` for manifest-based operations rooted in a subfolder
 - [Authentication and OIDC](./authentication-and-oidc.md)
   - PAT, Basic Auth, Azure RM OIDC (Azure Pipelines), GitHub OIDC
   - Service principal setup in Azure

--- a/docs/azure-pipelines.md
+++ b/docs/azure-pipelines.md
@@ -50,6 +50,7 @@ These appear across multiple operations.
 ### Manifest / package source
 
 - `manifestFile`
+- `workingDirectory`
 - `localizationRoot`
 - `use` (`manifest` or `vsix`) for `package`, `publish`, and `waitForInstallation`
 - `vsixFile` (publish from VSIX)
@@ -75,7 +76,7 @@ Creates a VSIX from manifest files.
 - Required:
   - `operation: package`
 - Optional:
-  - `manifestFile`, `manifestFileJs`, `overridesFile`, `localizationRoot`
+  - `manifestFile`, `workingDirectory`, `manifestFileJs`, `overridesFile`, `localizationRoot`
   - `publisherId`, `extensionId`
   - `extensionVersion`, `extensionName`, `extensionVisibility`, `extensionPricing`
   - `outputPath`
@@ -93,7 +94,7 @@ Publishes to Marketplace from manifest or prebuilt VSIX.
   - `use`
   - If `use = vsix`: `vsixFile`
 - Optional:
-  - `manifestFile`, `manifestFileJs`, `overridesFile`, `localizationRoot`
+  - `manifestFile`, `workingDirectory`, `manifestFileJs`, `overridesFile`, `localizationRoot`
   - `publisherId`, `extensionId`
   - `extensionVersion`, `extensionName`, `extensionVisibility`, `extensionPricing`
   - `noWaitValidation`
@@ -110,7 +111,7 @@ Removes an extension from Marketplace.
   - `connectionType` + matching connection input
 - Optional:
   - `publisherId`, `extensionId` (can be inferred from `manifestFile` or `vsixFile`)
-  - `manifestFile`, `vsixFile`
+  - `manifestFile`, `workingDirectory`, `vsixFile`
   - `tfxVersion`
 
 ### `share`
@@ -123,7 +124,7 @@ Shares a private extension with organizations.
   - `accounts` (newline-separated)
 - Optional:
   - `publisherId`, `extensionId` (can be inferred from `manifestFile` or `vsixFile`)
-  - `manifestFile`, `vsixFile`
+  - `manifestFile`, `workingDirectory`, `vsixFile`
   - `tfxVersion`
 
 ### `unshare`
@@ -136,7 +137,7 @@ Revokes sharing from organizations.
   - `accounts` (newline-separated)
 - Optional:
   - `publisherId`, `extensionId` (can be inferred from `manifestFile` or `vsixFile`)
-  - `manifestFile`, `vsixFile`
+  - `manifestFile`, `workingDirectory`, `vsixFile`
   - `tfxVersion`
 
 ### `install`
@@ -149,7 +150,7 @@ Installs extension to one or more Azure DevOps organizations.
   - `accounts` (newline-separated)
 - Optional:
   - `publisherId`, `extensionId` (can be inferred from `manifestFile` or `vsixFile`)
-  - `manifestFile`, `vsixFile`
+  - `manifestFile`, `workingDirectory`, `vsixFile`
   - `extensionVersion`
   - `tfxVersion`
 
@@ -178,7 +179,7 @@ Resolves the proposed extension version from one or more sources. The highest va
   - `versionSource` (default: `marketplace`; newline-separated list of `marketplace`, `manifest`, `vsix`, or semver literals)
   - `marketplaceVersionAction` (`None`, `Major`, `Minor`, `Patch`; only applies to the marketplace source; alias: `versionAction`)
   - `setBuildNumber`
-  - `use`, `vsixFile`, `manifestFile`
+  - `use`, `vsixFile`, `manifestFile`, `workingDirectory`
   - `tfxVersion`
 
 ### `waitForValidation`
@@ -190,7 +191,7 @@ Polls Marketplace validation result.
   - `connectionType` + matching connection input
 - Optional:
   - `publisherId`, `extensionId` (can be inferred from `manifestFile` or `vsixFile`)
-  - `manifestFile`, `vsixFile`
+  - `manifestFile`, `workingDirectory`, `vsixFile`
   - `maxRetries`, `minTimeout`, `maxTimeout`
   - `tfxVersion`
 
@@ -208,8 +209,23 @@ Verifies tasks are available after install.
     - `expectedTasks` (JSON)
     - `manifestFile`
     - `vsixFile`
+  - `workingDirectory` when `manifestFile` points to manifests under a subfolder
   - `timeoutMinutes`, `pollingIntervalSeconds`
   - `tfxVersion`
+
+## Working directory for manifest-based operations
+
+Use `workingDirectory` when your extension manifest lives in a subfolder and you want `manifestFile` patterns to stay relative to that folder.
+
+```yaml
+- task: azdo-marketplace@6
+  inputs:
+    operation: package
+    workingDirectory: $(Build.SourcesDirectory)/tests/sample-extension
+    manifestFile: vss-extension.json
+```
+
+When `workingDirectory` is omitted, manifest discovery falls back to the current working directory.
 
 ## Outputs
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -45,6 +45,7 @@ This repository ships a **unified JavaScript action** and **composite command wr
 ### Packaging/publish source and overrides
 
 - `manifest-file`
+- `working-directory`
 - `manifest-file-js`
 - `overrides-file`
 - `use` (`manifest` or `vsix`)
@@ -76,7 +77,7 @@ This repository ships a **unified JavaScript action** and **composite command wr
   - `operation: package`
 - Optional:
   - `publisher-id`, `extension-id`
-  - `manifest-file`, `manifest-file-js`, `overrides-file`
+  - `manifest-file`, `working-directory`, `manifest-file-js`, `overrides-file`
   - `extension-version`, `extension-name`, `extension-visibility`
   - `output-path`
   - `bypass-validation`, `update-tasks-version`, `update-tasks-id`
@@ -91,7 +92,7 @@ This repository ships a **unified JavaScript action** and **composite command wr
   - `vsix-file` when `use=vsix`
 - Optional:
   - identity inputs
-  - manifest inputs (`manifest-file`, `manifest-file-js`, `overrides-file`)
+  - manifest inputs (`manifest-file`, `working-directory`, `manifest-file-js`, `overrides-file`)
   - metadata override inputs
   - `share-with`, `no-wait-validation`, `update-tasks-version`, `update-tasks-id`
 
@@ -102,7 +103,7 @@ This repository ships a **unified JavaScript action** and **composite command wr
   - auth inputs
 - Optional:
   - `publisher-id`, `extension-id` (can be inferred from `manifest-file` or `vsix-file`)
-  - `manifest-file`, `vsix-file`
+  - `manifest-file`, `working-directory`, `vsix-file`
   - tooling/service URL overrides
 
 ### `share`
@@ -113,7 +114,7 @@ This repository ships a **unified JavaScript action** and **composite command wr
   - `share-with`
 - Optional:
   - `publisher-id`, `extension-id` (can be inferred from `manifest-file` or `vsix-file`)
-  - `manifest-file`, `vsix-file`
+  - `manifest-file`, `working-directory`, `vsix-file`
 
 ### `unshare`
 
@@ -123,7 +124,7 @@ This repository ships a **unified JavaScript action** and **composite command wr
   - `unshare-with`
 - Optional:
   - `publisher-id`, `extension-id` (can be inferred from `manifest-file` or `vsix-file`)
-  - `manifest-file`, `vsix-file`
+  - `manifest-file`, `working-directory`, `vsix-file`
 
 ### `install`
 
@@ -133,7 +134,7 @@ This repository ships a **unified JavaScript action** and **composite command wr
   - `accounts`
 - Optional:
   - `publisher-id`, `extension-id` (can be inferred from `manifest-file` or `vsix-file`)
-  - `manifest-file`, `vsix-file`
+  - `manifest-file`, `working-directory`, `vsix-file`
   - `extension-version`
 
 ### `show`
@@ -157,7 +158,7 @@ Resolves the proposed extension version from one or more sources. The highest va
 - Optional:
   - `version-source` (default: `marketplace`; newline-separated list of `marketplace`, `manifest`, `vsix`, or semver literals)
   - `marketplace-version-action` (`None`, `Major`, `Minor`, `Patch`; only applies to the marketplace source)
-  - `use`, `vsix-file`, `manifest-file`
+  - `use`, `vsix-file`, `manifest-file`, `working-directory`
 
 ### `wait-for-validation`
 
@@ -166,7 +167,7 @@ Resolves the proposed extension version from one or more sources. The highest va
   - auth inputs
 - Optional:
   - `publisher-id`, `extension-id` (can be inferred from `manifest-file` or `vsix-file`)
-  - `manifest-file`, `vsix-file`
+  - `manifest-file`, `working-directory`, `vsix-file`
   - `max-retries`, `min-timeout`, `max-timeout`
 
 ### `wait-for-installation`
@@ -179,7 +180,22 @@ Resolves the proposed extension version from one or more sources. The highest va
   - `publisher-id` (if omitted, inferred from `vsix-file` when provided)
   - `extension-id` (if omitted, inferred from `vsix-file` when provided)
   - one of `expected-tasks`, `manifest-file`, `vsix-file`
+  - `working-directory` when `manifest-file` points to manifests under a subfolder
   - `timeout-minutes`, `polling-interval-seconds`
+
+## Working directory for manifest-based operations
+
+Use `working-directory` when your extension manifest lives in a subfolder and you want `manifest-file` patterns to stay relative to that folder.
+
+```yaml
+- uses: jessehouwing/azdo-marketplace@v6
+  with:
+    operation: package
+    working-directory: tests/sample-extension
+    manifest-file: vss-extension.json
+```
+
+When `working-directory` is omitted, manifest discovery falls back to the current working directory.
 
 ## Unified action outputs
 

--- a/docs/migrate-azure-pipelines-v5-to-github-actions.md
+++ b/docs/migrate-azure-pipelines-v5-to-github-actions.md
@@ -37,6 +37,7 @@ Common conversions from Azure Pipelines-style names to GitHub Actions inputs:
 - `extensionId` → `extension-id`
 - `extensionTag` → `extension-id`
 - `manifestFile` → `manifest-file`
+- `rootFolder` → `working-directory`
 - `use` → `use` (publish flows)
 - `vsixFile` → `vsix-file`
 - `extensionVersion` → `extension-version`
@@ -54,6 +55,7 @@ Common conversions from Azure Pipelines-style names to GitHub Actions inputs:
 
 Package/publish metadata inputs available in v6:
 
+- `working-directory` for manifest-based operations when your extension files live below the repository root.
 - `localization-root` for localization files in manifest-based package/publish flows.
 - `extension-pricing` (`default`, `free`, `paid`) to override marketplace pricing metadata.
 - Publish-time sharing input is removed; run `operation: share` with `accounts` after publish.

--- a/docs/migrate-azure-pipelines-v5-to-v6.md
+++ b/docs/migrate-azure-pipelines-v5-to-v6.md
@@ -82,6 +82,7 @@ Use this mapping carefully when updating YAML:
 | `manifestGlobs`, `manifestPath`                              | `manifestFile`                                           | Single multi-line manifest input used by package, publish, and waitForInstallation.                    |
 | `updateTasksVersion` (boolean) + `updateTasksVersionType`    | `updateTasksVersion` (`none`\|`major`\|`minor`\|`patch`) | `none` replaces the old disabled/false behavior.                                                       |
 | `serviceUrl` for install/wait-install style flows            | `accounts`                                               | `install` and `waitForInstallation` no longer take `serviceUrl`; each account resolves to service URL. |
+| `rootFolder`                                                 | `workingDirectory`                                       | Base path for manifest-based operations when manifests live in a subfolder.                            |
 | `extensionTag`                                               | _(removed)_                                              | Compose full value into `extensionId` yourself.                                                        |
 | `outputVariable` custom name settings                        | _(removed)_                                              | Use built-in task output variables instead.                                                            |
 | `versionAction`                                              | `marketplaceVersionAction`                               | **Removed** as alias. Use `marketplaceVersionAction` instead.                                          |
@@ -166,9 +167,9 @@ For OIDC setup and Entra workload federation details, see:
 
 ## Path handling changes
 
-- `rootFolder` is removed in v6 Azure Pipelines task configuration.
-- Unrooted file operations now resolve from the current working directory.
-- Keep `manifestFile` and `localizationRoot` paths relative to the working directory.
+- Use `workingDirectory` in v6 when your manifests live in a subfolder.
+- If `workingDirectory` is omitted, manifest-based operations resolve from the current working directory.
+- Keep `manifestFile`, `manifestFileJs`, `overridesFile`, and `localizationRoot` paths relative to `workingDirectory` when it is specified.
 
 ## Version resolution changes (queryVersion)
 

--- a/docs/migrate-azure-pipelines-v6-to-github-actions.md
+++ b/docs/migrate-azure-pipelines-v6-to-github-actions.md
@@ -47,6 +47,7 @@ Common input mappings:
 - `publisherId` → `publisher-id`
 - `extensionId` → `extension-id`
 - `manifestFile` → `manifest-file`
+- `workingDirectory` → `working-directory`
 - `use` → `use` (publish flows)
 - `vsixFile` → `vsix-file`
 - `extensionVersion` → `extension-version`
@@ -61,6 +62,7 @@ Common input mappings:
 - Use `accounts` for `install`, `share`, `unshare`, and wait operations on both platforms.
 - Do not map any publish sharing input; publish-time sharing was removed. Use a dedicated `share` step with `accounts`.
 - For `install`, `share`, `unshare`, `unpublish`, and `waitForValidation`/`wait-for-validation`, identity can be inferred from either manifest (`manifestFile`/`manifest-file`) or VSIX (`vsixFile`/`vsix-file`) inputs.
+- For manifest-based flows, map Azure Pipelines `workingDirectory` to GitHub Actions `working-directory` to keep `manifestFile`/`manifest-file` paths relative to the same subfolder.
 
 ## Account input mapping
 

--- a/install/README.md
+++ b/install/README.md
@@ -49,6 +49,17 @@ Install an Azure DevOps extension to specific accounts/organizations.
       myorg2
 ```
 
+### Install Using Manifest Identity Fallback from a Subfolder
+
+```yaml
+- uses: jessehouwing/azdo-marketplace/install@v6
+  with:
+    token: ${{ secrets.MARKETPLACE_TOKEN }}
+    working-directory: './extension'
+    manifest-file: 'vss-extension.json'
+    accounts: 'myorg'
+```
+
 ### With OIDC Authentication
 
 ```yaml
@@ -76,6 +87,7 @@ Install an Azure DevOps extension to specific accounts/organizations.
 Identity (choose one):
 
 - `publisher-id` + `extension-id`
+- `manifest-file` (with optional `working-directory`) as a fallback source for identity metadata
 - `vsix-file` (fallback source for identity metadata)
 
 OR
@@ -95,6 +107,8 @@ OR
 
 #### Identity Fallback
 
+- `manifest-file`: Manifest path(s) used to infer `publisher-id` and `extension-id` when omitted
+- `working-directory`: Base directory for `manifest-file` when manifests live in a subfolder
 - `vsix-file`: Path to VSIX file used to infer `publisher-id` and `extension-id` when omitted
 
 ## Outputs
@@ -152,6 +166,8 @@ jobs:
 - `publisher-id`: Identifies the publisher that owns the extension to install.
 - `extension-id`: Identifies the extension to install.
 - `vsix-file`: Provides VSIX-based identity fallback when publisher/extension IDs are omitted.
+- `manifest-file`: Provides manifest-based identity fallback when publisher/extension IDs are omitted.
+- `working-directory`: Sets the base path used to resolve `manifest-file` in subfolder-based layouts.
 - `accounts`: Lists target organizations/accounts where the extension is installed.
 
 ## GitHub Marketplace outputs

--- a/install/action.schema.yaml
+++ b/install/action.schema.yaml
@@ -37,6 +37,9 @@ inputs:
     items:
       type: string
 
+  working-directory:
+    type: string
+
   vsix-file:
     type: string
 

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -122,7 +122,7 @@ inputs:
 
       - Defaults to `vss-extension.json` if not specified
       - Can specify multiple manifest files
-      - Patterns are relative to the current working directory
+      - Patterns are relative to `working-directory` when specified, otherwise the current working directory
       - For install/share/unpublish/unshare/wait-for-validation/query-version:
         used as fallback source for publisher-id and extension-id when not specified
 
@@ -132,6 +132,20 @@ inputs:
       manifests/dev/vss-extension.json
       manifests/prod/vss-extension.json
       ```
+    required: false
+  working-directory:
+    description: |-
+      **Working directory** used as the base path for manifest-based operations.
+
+      Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
+      Required for: none.
+      Default: current working directory
+
+      - Manifest discovery and `manifest-file` patterns are resolved from this directory
+      - Use this when your extension manifest lives in a subfolder
+      - If not specified, the current working directory is used
+
+      **Example:** `tests/sample-extension`
     required: false
   vsix-file:
     description: |-
@@ -186,5 +200,6 @@ runs:
         publisher-id: ${{ inputs.publisher-id }}
         extension-id: ${{ inputs.extension-id }}
         manifest-file: ${{ inputs.manifest-file }}
+        working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}
         accounts: ${{ inputs.accounts }}

--- a/package/README.md
+++ b/package/README.md
@@ -34,6 +34,16 @@ Create a .vsix package file for an Azure DevOps extension from your extension ma
     output-path: './dist'
 ```
 
+### Manifest in a Subfolder
+
+```yaml
+- uses: jessehouwing/azdo-marketplace/package@v6
+  with:
+    working-directory: './my-extension'
+    manifest-file: 'vss-extension.json'
+    output-path: './dist'
+```
+
 ## Inputs
 
 ### Required Inputs
@@ -63,6 +73,7 @@ None - all inputs are optional with sensible defaults.
 #### Manifest Source
 
 - `manifest-file`: Manifest file path(s), newline-separated (default: `vss-extension.json`)
+- `working-directory`: Base directory for manifest-based operations; `manifest-file` patterns resolve from here when specified
 - `manifest-file-js`: JS manifest module path for tfx `--manifest-js`
 - `overrides-file`: JSON overrides file for tfx `--overrides-file` (merged with generated overrides)
 
@@ -134,6 +145,7 @@ jobs:
 - `publisher-id`: Overrides publisher identity used in packaging.
 - `extension-id`: Overrides extension identity used in packaging.
 - `manifest-file`: Provides one or more manifest files for package input.
+- `working-directory`: Sets the base path used to resolve `manifest-file` in subfolder-based layouts.
 - `manifest-file-js`: Provides a JS manifest module for `tfx --manifest-js`.
 - `overrides-file`: Provides an overrides JSON file merged into the packaging manifest.
 - `extension-version`: Overrides extension version in the package.

--- a/package/action.schema.yaml
+++ b/package/action.schema.yaml
@@ -27,6 +27,9 @@ inputs:
     items:
       type: string
 
+  working-directory:
+    type: string
+
   manifest-file-js:
     type: string
 

--- a/package/action.yaml
+++ b/package/action.yaml
@@ -63,7 +63,7 @@ inputs:
 
       - Defaults to `vss-extension.json` if not specified
       - Can specify multiple manifest files
-      - Patterns are relative to the current working directory
+      - Patterns are relative to `working-directory` when specified, otherwise the current working directory
       - For install/share/unpublish/unshare/wait-for-validation/query-version:
         used as fallback source for publisher-id and extension-id when not specified
 
@@ -73,6 +73,20 @@ inputs:
       manifests/dev/vss-extension.json
       manifests/prod/vss-extension.json
       ```
+    required: false
+  working-directory:
+    description: |-
+      **Working directory** used as the base path for manifest-based operations.
+
+      Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
+      Required for: none.
+      Default: current working directory
+
+      - Manifest discovery and `manifest-file` patterns are resolved from this directory
+      - Use this when your extension manifest lives in a subfolder
+      - If not specified, the current working directory is used
+
+      **Example:** `tests/sample-extension`
     required: false
   manifest-file-js:
     description: |-
@@ -255,6 +269,7 @@ runs:
         publisher-id: ${{ inputs.publisher-id }}
         extension-id: ${{ inputs.extension-id }}
         manifest-file: ${{ inputs.manifest-file }}
+        working-directory: ${{ inputs.working-directory }}
         manifest-file-js: ${{ inputs.manifest-file-js }}
         overrides-file: ${{ inputs.overrides-file }}
         extension-version: ${{ inputs.extension-version }}

--- a/packages/azdo-task/src/__tests__/main.test.ts
+++ b/packages/azdo-task/src/__tests__/main.test.ts
@@ -176,6 +176,7 @@ describe('Azure DevOps main entrypoint', () => {
       inputs: {
         operation: 'package',
         tfxVersion: 'built-in',
+        workingDirectory: 'tests/sample-extension',
         manifestFile: 'vss-extension.json',
         publisherId: 'publisher',
         extensionId: 'extension',
@@ -200,6 +201,7 @@ describe('Azure DevOps main entrypoint', () => {
 
     expect(packageExtensionMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        rootFolder: 'tests/sample-extension',
         publisherId: 'publisher',
         extensionId: 'extension',
         extensionVersion: '1.2.3',
@@ -223,6 +225,7 @@ describe('Azure DevOps main entrypoint', () => {
         tfxVersion: 'path',
         connectionType: 'PAT',
         connectionNamePAT: 'svc-connection',
+        workingDirectory: 'tests/sample-extension',
         use: 'manifest',
         manifestFileJs: 'manifests/build-manifest.js',
         overridesFile: 'manifests/overrides.json',
@@ -241,6 +244,7 @@ describe('Azure DevOps main entrypoint', () => {
     expect(validateAccountUrlMock).toHaveBeenCalledWith('https://dev.azure.com/org');
     expect(publishExtensionMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        rootFolder: 'tests/sample-extension',
         manifestFileJs: 'manifests/build-manifest.js',
         overridesFile: 'manifests/overrides.json',
       }),
@@ -623,6 +627,7 @@ describe('Azure DevOps main entrypoint', () => {
         operation: 'queryVersion',
         connectionType: 'PAT',
         connectionNamePAT: 'svc-connection',
+        workingDirectory: 'tests/sample-extension',
         publisherId: 'publisher',
         extensionId: 'extension',
         marketplaceVersionAction: 'MAJOR',
@@ -637,6 +642,7 @@ describe('Azure DevOps main entrypoint', () => {
 
     expect(queryVersionMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        rootFolder: 'tests/sample-extension',
         marketplaceVersionAction: 'Major',
       }),
       expect.anything(),
@@ -764,6 +770,7 @@ describe('Azure DevOps main entrypoint', () => {
         operation: 'waitForInstallation',
         connectionType: 'PAT',
         connectionNamePAT: 'svc-connection',
+        workingDirectory: 'tests/sample-extension',
         use: 'manifest',
         vsixFile: vsixFile,
       },
@@ -777,7 +784,10 @@ describe('Azure DevOps main entrypoint', () => {
     await importMainAndFlush();
 
     expect(waitForInstallationMock).toHaveBeenCalledWith(
-      expect.objectContaining({ vsixFile }),
+      expect.objectContaining({
+        rootFolder: 'tests/sample-extension',
+        vsixFile,
+      }),
       expect.anything(),
       platform
     );
@@ -789,6 +799,7 @@ describe('Azure DevOps main entrypoint', () => {
         operation: 'install',
         connectionType: 'PAT',
         connectionNamePAT: 'svc-connection',
+        workingDirectory: 'tests/sample-extension',
       },
       delimitedInputs: {
         'manifestFile|\n': ['vss-extension.json'],
@@ -802,6 +813,7 @@ describe('Azure DevOps main entrypoint', () => {
 
     expect(installExtensionMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        rootFolder: 'tests/sample-extension',
         manifestGlobs: ['vss-extension.json'],
       }),
       expect.anything(),

--- a/packages/azdo-task/src/main.ts
+++ b/packages/azdo-task/src/main.ts
@@ -251,6 +251,7 @@ async function runPackage(platform: AzdoAdapter, tfxManager: TfxManager): Promis
   const extensionPricingInput = platform.getInput('extensionPricing');
 
   const options = {
+    rootFolder: platform.getPathInput('workingDirectory') || platform.getInput('workingDirectory'),
     localizationRoot: platform.getPathInput('localizationRoot'),
     manifestGlobs: platform.getDelimitedInput('manifestFile', '\n'),
     manifestFileJs: platform.getPathInput('manifestFileJs'),
@@ -293,6 +294,10 @@ async function runPublish(
   const result = await publishExtension(
     {
       publishSource: use,
+      rootFolder:
+        use === 'manifest'
+          ? platform.getPathInput('workingDirectory') || platform.getInput('workingDirectory')
+          : undefined,
       vsixFile: use === 'vsix' ? platform.getPathInput('vsixFile', true) : undefined,
       manifestGlobs:
         use === 'manifest' ? platform.getDelimitedInput('manifestFile', '\n') : undefined,
@@ -337,6 +342,8 @@ async function runUnpublish(
       publisherId: platform.getInput('publisherId'),
       extensionId: platform.getInput('extensionId'),
       vsixFile: platform.getPathInput('vsixFile') || platform.getInput('vsixFile'),
+      rootFolder:
+        platform.getPathInput('workingDirectory') || platform.getInput('workingDirectory'),
       manifestGlobs: platform.getDelimitedInput('manifestFile', '\n'),
     },
     auth,
@@ -355,6 +362,8 @@ async function runShare(
       publisherId: platform.getInput('publisherId'),
       extensionId: platform.getInput('extensionId'),
       vsixFile: platform.getPathInput('vsixFile') || platform.getInput('vsixFile'),
+      rootFolder:
+        platform.getPathInput('workingDirectory') || platform.getInput('workingDirectory'),
       manifestGlobs: platform.getDelimitedInput('manifestFile', '\n'),
       shareWith: platform.getDelimitedInput('accounts', '\n', true),
     },
@@ -374,6 +383,8 @@ async function runUnshare(
       publisherId: platform.getInput('publisherId'),
       extensionId: platform.getInput('extensionId'),
       vsixFile: platform.getPathInput('vsixFile') || platform.getInput('vsixFile'),
+      rootFolder:
+        platform.getPathInput('workingDirectory') || platform.getInput('workingDirectory'),
       manifestGlobs: platform.getDelimitedInput('manifestFile', '\n'),
       unshareWith: platform.getDelimitedInput('accounts', '\n', true),
     },
@@ -393,6 +404,8 @@ async function runInstall(
       publisherId: platform.getInput('publisherId'),
       extensionId: platform.getInput('extensionId'),
       vsixFile: platform.getPathInput('vsixFile') || platform.getInput('vsixFile'),
+      rootFolder:
+        platform.getPathInput('workingDirectory') || platform.getInput('workingDirectory'),
       manifestGlobs: platform.getDelimitedInput('manifestFile', '\n'),
       accounts: platform.getDelimitedInput('accounts', '\n', true),
     },
@@ -457,6 +470,8 @@ async function runQueryVersion(
       versionSource,
       use: (platform.getInput('use') || 'manifest') as 'manifest' | 'vsix',
       vsixFile: platform.getPathInput('vsixFile') || undefined,
+      rootFolder:
+        platform.getPathInput('workingDirectory') || platform.getInput('workingDirectory'),
       manifestGlobs: platform.getDelimitedInput('manifestFile', '\n'),
     },
     auth,
@@ -486,6 +501,8 @@ async function runWaitForValidation(
       publisherId: platform.getInput('publisherId'),
       extensionId: platform.getInput('extensionId'),
       vsixFile: platform.getPathInput('vsixFile') || platform.getInput('vsixFile'),
+      rootFolder:
+        platform.getPathInput('workingDirectory') || platform.getInput('workingDirectory'),
       manifestGlobs: platform.getDelimitedInput('manifestFile', '\n'),
       extensionVersion: platform.getInput('extensionVersion'),
       timeoutMinutes: timeoutMinutesInput ? parseInt(timeoutMinutesInput, 10) : undefined,
@@ -527,6 +544,8 @@ async function runWaitForInstallation(platform: AzdoAdapter, auth: AuthCredentia
       extensionId: platform.getInput('extensionId'),
       accounts: platform.getDelimitedInput('accounts', '\n', true),
       expectedTasks,
+      rootFolder:
+        platform.getPathInput('workingDirectory') || platform.getInput('workingDirectory'),
       manifestFiles:
         use === 'manifest' ? platform.getDelimitedInput('manifestFile', '\n') : undefined,
       vsixFile,

--- a/packages/azdo-task/task.json
+++ b/packages/azdo-task/task.json
@@ -107,12 +107,20 @@
       "label": "Use",
       "required": true,
       "defaultValue": "manifest",
-      "helpMarkDown": "**Input source mode** for operations that support manifest or VSIX input.\n\n- **Manifest files**: Use `manifestFile` (and optional `localizationRoot`) from the current working directory\n- **VSIX file**: Use `vsixFile`",
+      "helpMarkDown": "**Input source mode** for operations that support manifest or VSIX input.\n\n- **Manifest files**: Use `manifestFile` (and optional `localizationRoot`) from `workingDirectory` when specified, otherwise the current working directory\n- **VSIX file**: Use `vsixFile`",
       "visibleRule": "operation = package || operation = publish || operation = waitForInstallation || operation = queryVersion",
       "options": {
         "manifest": "Manifest files",
         "vsix": "VSIX file"
       }
+    },
+    {
+      "name": "workingDirectory",
+      "type": "filePath",
+      "label": "Working Directory",
+      "required": false,
+      "helpMarkDown": "**Working directory** used as the base path for manifest-based operations.\n\n- Manifest discovery and `manifestFile` patterns are resolved from this directory\n- Use this when your extension manifest lives in a subfolder\n- If not specified, the current working directory is used\n\n**Example**: `$(Build.SourcesDirectory)/tests/sample-extension`",
+      "visibleRule": "use = manifest || operation = unpublish || operation = share || operation = unshare || operation = install || operation = waitForValidation || operation = waitForInstallation"
     },
     {
       "name": "localizationRoot",
@@ -127,7 +135,7 @@
       "type": "multiLine",
       "label": "Manifest File(s)",
       "required": false,
-      "helpMarkDown": "**Manifest file path(s)** (one per line).\n\n- Defaults to `vss-extension.json` if not specified\n- Supports multiple manifest files\n- Paths are relative to the current working directory\n- For install/share/unpublish/unshare/waitForValidation/queryVersion:\n  used as fallback source for Publisher ID and Extension ID when not specified\n\n**Examples**:\n- `vss-extension.json`\n- `manifests/dev/vss-extension.json`\n- `manifests/prod/vss-extension.json`",
+      "helpMarkDown": "**Manifest file path(s)** (one per line).\n\n- Defaults to `vss-extension.json` if not specified\n- Supports multiple manifest files\n- Paths are relative to `workingDirectory` when specified, otherwise the current working directory\n- For install/share/unpublish/unshare/waitForValidation/queryVersion:\n  used as fallback source for Publisher ID and Extension ID when not specified\n\n**Examples**:\n- `vss-extension.json`\n- `manifests/dev/vss-extension.json`\n- `manifests/prod/vss-extension.json`",
       "visibleRule": "use = manifest || operation = unpublish || operation = share || operation = unshare || operation = install || operation = waitForValidation"
     },
     {

--- a/packages/core/src/commands/wait-for-installation.ts
+++ b/packages/core/src/commands/wait-for-installation.ts
@@ -1,10 +1,11 @@
 import { WebApi, getPersonalAccessTokenHandler } from 'azure-devops-node-api';
 import type { ITaskAgentApi } from 'azure-devops-node-api/TaskAgentApi.js';
 import type { TaskDefinition } from 'azure-devops-node-api/interfaces/TaskAgentInterfaces.js';
+import { cwd } from 'process';
 import type { AuthCredentials } from '../auth.js';
 import { resolveExtensionIdentity } from '../extension-identity.js';
 import type { ExtensionManifest } from '../manifest-reader.js';
-import { readManifest, resolveTaskManifestPaths } from '../manifest-utils.js';
+import { readManifest, resolveManifestPaths, resolveTaskManifestPaths } from '../manifest-utils.js';
 import { normalizeAccountsToServiceUrls } from '../organization-utils.js';
 import type { IPlatformAdapter } from '../platform.js';
 import { VsixReader } from '../vsix-reader.js';
@@ -19,6 +20,7 @@ export interface WaitForInstallationOptions {
   extensionId?: string;
   accounts: string[]; // Target organization names or URLs
   expectedTasks?: ExpectedTask[]; // Tasks with expected versions
+  rootFolder?: string; // Root folder for manifest discovery
   manifestFiles?: string[]; // Paths to extension manifests (vss-extension.json) to read task versions
   vsixFile?: string; // Path to VSIX file to read task versions from
   timeoutMinutes?: number; // Default: 10
@@ -63,10 +65,12 @@ async function resolveExpectedTasks(
   if (options.manifestFiles && options.manifestFiles.length > 0) {
     try {
       platform.debug(`Reading task versions from ${options.manifestFiles.length} manifest file(s)`);
+      const rootFolder = options.rootFolder ?? cwd();
+      const manifestFiles = await resolveManifestPaths(rootFolder, options.manifestFiles, platform);
 
       const expectedByTask = new Map<string, Set<string>>();
 
-      for (const manifestFile of options.manifestFiles) {
+      for (const manifestFile of manifestFiles) {
         try {
           const manifest = (await readManifest(manifestFile, platform)) as ExtensionManifest;
           const taskPaths = resolveTaskManifestPaths(manifest, manifestFile, platform);

--- a/packages/github-action/src/__tests__/main.test.ts
+++ b/packages/github-action/src/__tests__/main.test.ts
@@ -169,6 +169,7 @@ describe('GitHub Action main entrypoint', () => {
       inputs: {
         operation: 'package',
         'tfx-version': 'built-in',
+        'working-directory': 'tests/sample-extension',
         'publisher-id': 'publisher',
         'extension-id': 'extension',
         'extension-version': '1.2.3',
@@ -193,6 +194,7 @@ describe('GitHub Action main entrypoint', () => {
 
     expect(packageExtensionMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        rootFolder: 'tests/sample-extension',
         publisherId: 'publisher',
         extensionId: 'extension',
         extensionVersion: '1.2.3',
@@ -217,6 +219,7 @@ describe('GitHub Action main entrypoint', () => {
         operation: 'publish',
         'tfx-version': '^0.17.0',
         'auth-type': 'oidc',
+        'working-directory': 'tests/sample-extension',
         use: 'manifest',
         'output-path': '/out',
         'manifest-file-js': 'manifests/build-manifest.js',
@@ -241,6 +244,7 @@ describe('GitHub Action main entrypoint', () => {
     expect(validateAccountUrlMock).toHaveBeenCalledWith('https://dev.azure.com/org');
     expect(publishExtensionMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        rootFolder: 'tests/sample-extension',
         outputPath: '/out',
         manifestFileJs: 'manifests/build-manifest.js',
         overridesFile: 'manifests/overrides.json',
@@ -501,6 +505,7 @@ describe('GitHub Action main entrypoint', () => {
       inputs: {
         operation: 'unpublish',
         'auth-type': 'pat',
+        'working-directory': 'tests/sample-extension',
         'vsix-file': '/tmp/extension.vsix',
       },
     });
@@ -512,6 +517,7 @@ describe('GitHub Action main entrypoint', () => {
       expect.objectContaining({
         publisherId: undefined,
         extensionId: undefined,
+        rootFolder: 'tests/sample-extension',
         vsixFile: '/tmp/extension.vsix',
       }),
       expect.anything(),
@@ -525,6 +531,7 @@ describe('GitHub Action main entrypoint', () => {
       inputs: {
         operation: 'install',
         'auth-type': 'pat',
+        'working-directory': 'tests/sample-extension',
       },
       delimitedInputs: {
         'manifest-file|\n': ['vss-extension.json'],
@@ -538,6 +545,7 @@ describe('GitHub Action main entrypoint', () => {
 
     expect(installExtensionMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        rootFolder: 'tests/sample-extension',
         manifestGlobs: ['vss-extension.json'],
       }),
       expect.anything(),
@@ -556,6 +564,7 @@ describe('GitHub Action main entrypoint', () => {
       inputs: {
         operation: 'query-version',
         'auth-type': 'pat',
+        'working-directory': 'tests/sample-extension',
         'publisher-id': 'publisher',
         'extension-id': 'extension',
         'marketplace-version-action': 'major',
@@ -567,6 +576,7 @@ describe('GitHub Action main entrypoint', () => {
 
     expect(queryVersionMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        rootFolder: 'tests/sample-extension',
         marketplaceVersionAction: 'Major',
       }),
       expect.anything(),
@@ -644,6 +654,7 @@ describe('GitHub Action main entrypoint', () => {
       inputs: {
         operation: 'wait-for-validation',
         'auth-type': 'pat',
+        'working-directory': 'tests/sample-extension',
         'publisher-id': 'publisher',
         'extension-id': 'extension',
         'extension-version': '1.2.3',
@@ -660,6 +671,7 @@ describe('GitHub Action main entrypoint', () => {
 
     expect(waitForValidationMock).toHaveBeenCalledWith(
       expect.objectContaining({
+        rootFolder: 'tests/sample-extension',
         extensionVersion: '1.2.3',
         timeoutMinutes: 14,
         pollingIntervalSeconds: 40,
@@ -669,5 +681,34 @@ describe('GitHub Action main entrypoint', () => {
       platform
     );
     expect(setFailedMock).toHaveBeenCalledWith('Validation failed with status: failed');
+  });
+
+  it('forwards working-directory to wait-for-installation', async () => {
+    const platform = createPlatformMock({
+      inputs: {
+        operation: 'wait-for-installation',
+        'auth-type': 'pat',
+        'working-directory': 'tests/sample-extension',
+        'publisher-id': 'publisher',
+        'extension-id': 'extension',
+      },
+      delimitedInputs: {
+        'manifest-file|\n': ['vss-extension.json'],
+        'accounts|\n': ['org1'],
+        'accounts|;': ['org1'],
+      },
+    });
+    githubAdapterCtorMock.mockReturnValue(platform);
+
+    await importMainAndFlush();
+
+    expect(waitForInstallationMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rootFolder: 'tests/sample-extension',
+        manifestFiles: ['vss-extension.json'],
+      }),
+      expect.anything(),
+      platform
+    );
   });
 });

--- a/packages/github-action/src/main.ts
+++ b/packages/github-action/src/main.ts
@@ -236,6 +236,7 @@ async function runPackage(platform: GitHubAdapter, tfxManager: TfxManager): Prom
   const extensionPricingInput = platform.getInput('extension-pricing');
 
   const options = {
+    rootFolder: platform.getInput('working-directory') || undefined,
     localizationRoot: platform.getInput('localization-root'),
     manifestGlobs: platform.getDelimitedInput('manifest-file', '\n'),
     manifestFileJs: platform.getInput('manifest-file-js'),
@@ -279,6 +280,10 @@ async function runPublish(
   const result = await publishExtension(
     {
       publishSource,
+      rootFolder:
+        publishSource === 'manifest'
+          ? platform.getInput('working-directory') || undefined
+          : undefined,
       vsixFile: publishSource === 'vsix' ? platform.getInput('vsix-file', true) : undefined,
       manifestGlobs:
         publishSource === 'manifest'
@@ -326,6 +331,7 @@ async function runUnpublish(
       publisherId: platform.getInput('publisher-id'),
       extensionId: platform.getInput('extension-id'),
       vsixFile: platform.getInput('vsix-file'),
+      rootFolder: platform.getInput('working-directory') || undefined,
       manifestGlobs: platform.getDelimitedInput('manifest-file', '\n'),
     },
     auth,
@@ -344,6 +350,7 @@ async function runShare(
       publisherId: platform.getInput('publisher-id'),
       extensionId: platform.getInput('extension-id'),
       vsixFile: platform.getInput('vsix-file'),
+      rootFolder: platform.getInput('working-directory') || undefined,
       manifestGlobs: platform.getDelimitedInput('manifest-file', '\n'),
       shareWith: platform.getDelimitedInput('accounts', '\n', true),
     },
@@ -363,6 +370,7 @@ async function runUnshare(
       publisherId: platform.getInput('publisher-id'),
       extensionId: platform.getInput('extension-id'),
       vsixFile: platform.getInput('vsix-file'),
+      rootFolder: platform.getInput('working-directory') || undefined,
       manifestGlobs: platform.getDelimitedInput('manifest-file', '\n'),
       unshareWith: platform.getDelimitedInput('accounts', '\n', true),
     },
@@ -382,6 +390,7 @@ async function runInstall(
       publisherId: platform.getInput('publisher-id'),
       extensionId: platform.getInput('extension-id'),
       vsixFile: platform.getInput('vsix-file'),
+      rootFolder: platform.getInput('working-directory') || undefined,
       manifestGlobs: platform.getDelimitedInput('manifest-file', '\n'),
       accounts: platform.getDelimitedInput('accounts', '\n', true),
     },
@@ -446,6 +455,7 @@ async function runQueryVersion(
       versionSource,
       use: (platform.getInput('use') || 'manifest') as 'manifest' | 'vsix',
       vsixFile: platform.getInput('vsix-file') || undefined,
+      rootFolder: platform.getInput('working-directory') || undefined,
       manifestGlobs: platform.getDelimitedInput('manifest-file', '\n'),
     },
     auth,
@@ -472,6 +482,7 @@ async function runWaitForValidation(
       extensionId: platform.getInput('extension-id'),
       vsixFile: platform.getInput('vsix-file'),
       extensionVersion: platform.getInput('extension-version'),
+      rootFolder: platform.getInput('working-directory') || undefined,
       manifestGlobs: platform.getDelimitedInput('manifest-file', '\n'),
       timeoutMinutes: timeoutMinutesInput ? parseInt(timeoutMinutesInput, 10) : undefined,
       pollingIntervalSeconds: pollingIntervalSecondsInput
@@ -513,6 +524,7 @@ async function runWaitForInstallation(
       extensionId: platform.getInput('extension-id'),
       accounts: platform.getDelimitedInput('accounts', '\n', true),
       expectedTasks,
+      rootFolder: platform.getInput('working-directory') || undefined,
       manifestFiles: platform.getDelimitedInput('manifest-file', '\n'),
       vsixFile: platform.getInput('vsix-file'),
       timeoutMinutes: parseInt(platform.getInput('timeout-minutes') || '10'),

--- a/publish/README.md
+++ b/publish/README.md
@@ -62,6 +62,16 @@ Publish an Azure DevOps extension to the Visual Studio Marketplace.
     update-tasks-id: 'true'
 ```
 
+### Publish from a Manifest in a Subfolder
+
+```yaml
+- uses: jessehouwing/azdo-marketplace/publish@v6
+  with:
+    token: ${{ secrets.MARKETPLACE_TOKEN }}
+    working-directory: './my-extension'
+    manifest-file: 'vss-extension.json'
+```
+
 ## Inputs
 
 ### Required Inputs
@@ -97,6 +107,7 @@ OR
 #### Manifest Source (when use is manifest)
 
 - `manifest-file`: Manifest file path(s), newline-separated
+- `working-directory`: Base directory for manifest-based operations; `manifest-file` patterns resolve from here when specified
 - `manifest-file-js`: JS manifest module path for tfx `--manifest-js`
 - `overrides-file`: JSON overrides file for tfx `--overrides-file` (merged with generated overrides)
 
@@ -170,6 +181,7 @@ jobs:
 - `extension-id`: Overrides extension identity used for publish.
 - `use`: Chooses publish source (`manifest` or `vsix`).
 - `manifest-file`: Provides one or more manifest files for manifest publishing.
+- `working-directory`: Sets the base path used to resolve manifest inputs in subfolder-based layouts.
 - `manifest-file-js`: Provides a JS manifest module for `tfx --manifest-js`.
 - `overrides-file`: Provides an overrides JSON file merged into manifest publishing.
 - `vsix-file`: Provides the VSIX path when publishing from VSIX source.

--- a/publish/action.schema.yaml
+++ b/publish/action.schema.yaml
@@ -54,6 +54,9 @@ inputs:
     items:
       type: string
 
+  working-directory:
+    type: string
+
   manifest-file-js:
     type: string
 

--- a/publish/action.yaml
+++ b/publish/action.yaml
@@ -157,7 +157,7 @@ inputs:
 
       - Defaults to `vss-extension.json` if not specified
       - Can specify multiple manifest files
-      - Patterns are relative to the current working directory
+      - Patterns are relative to `working-directory` when specified, otherwise the current working directory
       - For install/share/unpublish/unshare/wait-for-validation/query-version:
         used as fallback source for publisher-id and extension-id when not specified
 
@@ -167,6 +167,20 @@ inputs:
       manifests/dev/vss-extension.json
       manifests/prod/vss-extension.json
       ```
+    required: false
+  working-directory:
+    description: |-
+      **Working directory** used as the base path for manifest-based operations.
+
+      Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
+      Required for: none.
+      Default: current working directory
+
+      - Manifest discovery and `manifest-file` patterns are resolved from this directory
+      - Use this when your extension manifest lives in a subfolder
+      - If not specified, the current working directory is used
+
+      **Example:** `tests/sample-extension`
     required: false
   manifest-file-js:
     description: |-
@@ -368,6 +382,7 @@ runs:
         extension-id: ${{ inputs.extension-id }}
         use: ${{ inputs.use }}
         manifest-file: ${{ inputs.manifest-file }}
+        working-directory: ${{ inputs.working-directory }}
         manifest-file-js: ${{ inputs.manifest-file-js }}
         overrides-file: ${{ inputs.overrides-file }}
         vsix-file: ${{ inputs.vsix-file }}

--- a/query-version/README.md
+++ b/query-version/README.md
@@ -89,6 +89,17 @@ Only applies when `marketplace` is listed in `version-source`.
     version-source: manifest
 ```
 
+### Use version from a manifest in a subfolder
+
+```yaml
+- uses: jessehouwing/azdo-marketplace/query-version@v6
+  id: query
+  with:
+    version-source: manifest
+    working-directory: './extension'
+    manifest-file: 'vss-extension.json'
+```
+
 ### GitVersion integration (no auth required)
 
 ```yaml
@@ -144,6 +155,7 @@ Only applies when `marketplace` is listed in `version-source`.
 - `version-source`: Version sources to consider (newline-separated). Default: `marketplace`.
 - `marketplace-version-action`: Version increment strategy (`None`, `Major`, `Minor`, `Patch`). Default: `None`.
 - `manifest-file`: Manifest file path(s) for reading publisher/extension IDs.
+- `working-directory`: Base directory for `manifest-file` when manifests live in a subfolder.
 - `use`: Input source (`manifest` or `vsix`).
 - `vsix-file`: Path to pre-built `.vsix` file when `use` is `vsix`.
 

--- a/query-version/action.schema.yaml
+++ b/query-version/action.schema.yaml
@@ -60,6 +60,9 @@ inputs:
   manifest-file:
     type: string
 
+  working-directory:
+    type: string
+
   use:
     type: choice
     options:

--- a/query-version/action.yaml
+++ b/query-version/action.yaml
@@ -202,7 +202,7 @@ inputs:
 
       - Defaults to `vss-extension.json` if not specified
       - Can specify multiple manifest files
-      - Patterns are relative to the current working directory
+      - Patterns are relative to `working-directory` when specified, otherwise the current working directory
       - For install/share/unpublish/unshare/wait-for-validation/query-version:
         used as fallback source for publisher-id and extension-id when not specified
 
@@ -212,6 +212,20 @@ inputs:
       manifests/dev/vss-extension.json
       manifests/prod/vss-extension.json
       ```
+    required: false
+  working-directory:
+    description: |-
+      **Working directory** used as the base path for manifest-based operations.
+
+      Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
+      Required for: none.
+      Default: current working directory
+
+      - Manifest discovery and `manifest-file` patterns are resolved from this directory
+      - Use this when your extension manifest lives in a subfolder
+      - If not specified, the current working directory is used
+
+      **Example:** `tests/sample-extension`
     required: false
   use:
     description: |-
@@ -275,5 +289,6 @@ runs:
         version-source: ${{ inputs.version-source }}
         marketplace-version-action: ${{ inputs.marketplace-version-action }}
         manifest-file: ${{ inputs.manifest-file }}
+        working-directory: ${{ inputs.working-directory }}
         use: ${{ inputs.use }}
         vsix-file: ${{ inputs.vsix-file }}

--- a/share/README.md
+++ b/share/README.md
@@ -43,6 +43,17 @@ Share an Azure DevOps extension with specific organizations.
       myorg2
 ```
 
+### Share Using Manifest Identity Fallback from a Subfolder
+
+```yaml
+- uses: jessehouwing/azdo-marketplace/share@v6
+  with:
+    token: ${{ secrets.MARKETPLACE_TOKEN }}
+    working-directory: './extension'
+    manifest-file: 'vss-extension.json'
+    accounts: 'myorg'
+```
+
 ### With OIDC Authentication
 
 ```yaml
@@ -70,6 +81,7 @@ Share an Azure DevOps extension with specific organizations.
 Identity (choose one):
 
 - `publisher-id` + `extension-id`
+- `manifest-file` (with optional `working-directory`) as a fallback source for identity metadata
 - `vsix-file` (fallback source for identity metadata)
 
 OR
@@ -89,6 +101,8 @@ OR
 
 #### Identity Fallback
 
+- `manifest-file`: Manifest path(s) used to infer `publisher-id` and `extension-id` when omitted
+- `working-directory`: Base directory for `manifest-file` when manifests live in a subfolder
 - `vsix-file`: Path to VSIX file used to infer `publisher-id` and `extension-id` when omitted
 
 ## Outputs
@@ -139,6 +153,8 @@ jobs:
 - `publisher-id`: Identifies the publisher that owns the extension to share.
 - `extension-id`: Identifies the extension to share.
 - `vsix-file`: Provides VSIX-based identity fallback when publisher/extension IDs are omitted.
+- `manifest-file`: Provides manifest-based identity fallback when publisher/extension IDs are omitted.
+- `working-directory`: Sets the base path used to resolve `manifest-file` in subfolder-based layouts.
 - `accounts`: Lists organizations/accounts that receive extension access.
 
 ## GitHub Marketplace outputs

--- a/share/action.schema.yaml
+++ b/share/action.schema.yaml
@@ -43,6 +43,9 @@ inputs:
     items:
       type: string
 
+  working-directory:
+    type: string
+
   vsix-file:
     type: string
 

--- a/share/action.yaml
+++ b/share/action.yaml
@@ -144,7 +144,7 @@ inputs:
 
       - Defaults to `vss-extension.json` if not specified
       - Can specify multiple manifest files
-      - Patterns are relative to the current working directory
+      - Patterns are relative to `working-directory` when specified, otherwise the current working directory
       - For install/share/unpublish/unshare/wait-for-validation/query-version:
         used as fallback source for publisher-id and extension-id when not specified
 
@@ -154,6 +154,20 @@ inputs:
       manifests/dev/vss-extension.json
       manifests/prod/vss-extension.json
       ```
+    required: false
+  working-directory:
+    description: |-
+      **Working directory** used as the base path for manifest-based operations.
+
+      Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
+      Required for: none.
+      Default: current working directory
+
+      - Manifest discovery and `manifest-file` patterns are resolved from this directory
+      - Use this when your extension manifest lives in a subfolder
+      - If not specified, the current working directory is used
+
+      **Example:** `tests/sample-extension`
     required: false
   vsix-file:
     description: |-
@@ -209,5 +223,6 @@ runs:
         publisher-id: ${{ inputs.publisher-id }}
         extension-id: ${{ inputs.extension-id }}
         manifest-file: ${{ inputs.manifest-file }}
+        working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}
         accounts: ${{ inputs.accounts }}

--- a/unpublish/README.md
+++ b/unpublish/README.md
@@ -25,6 +25,16 @@ Remove an Azure DevOps extension from the Visual Studio Marketplace.
     vsix-file: ${{ steps.package.outputs.vsix-file }}
 ```
 
+### Unpublish Using Manifest Identity Fallback from a Subfolder
+
+```yaml
+- uses: jessehouwing/azdo-marketplace/unpublish@v6
+  with:
+    token: ${{ secrets.MARKETPLACE_TOKEN }}
+    working-directory: './extension'
+    manifest-file: 'vss-extension.json'
+```
+
 ### With OIDC Authentication
 
 ```yaml
@@ -50,6 +60,7 @@ Remove an Azure DevOps extension from the Visual Studio Marketplace.
 Identity (choose one):
 
 - `publisher-id` + `extension-id`
+- `manifest-file` (with optional `working-directory`) as a fallback source for identity metadata
 - `vsix-file` (fallback source for identity metadata)
 
 OR
@@ -69,6 +80,8 @@ OR
 
 #### Identity Fallback
 
+- `manifest-file`: Manifest path(s) used to infer `publisher-id` and `extension-id` when omitted
+- `working-directory`: Base directory for `manifest-file` when manifests live in a subfolder
 - `vsix-file`: Path to VSIX file used to infer `publisher-id` and `extension-id` when omitted
 
 ## Outputs
@@ -119,6 +132,8 @@ jobs:
 - `publisher-id`: Identifies the publisher that owns the extension to unpublish.
 - `extension-id`: Identifies the extension to unpublish.
 - `vsix-file`: Provides VSIX-based identity fallback when publisher/extension IDs are omitted.
+- `manifest-file`: Provides manifest-based identity fallback when publisher/extension IDs are omitted.
+- `working-directory`: Sets the base path used to resolve `manifest-file` in subfolder-based layouts.
 
 ## GitHub Marketplace outputs
 

--- a/unpublish/action.schema.yaml
+++ b/unpublish/action.schema.yaml
@@ -43,5 +43,8 @@ inputs:
     items:
       type: string
 
+  working-directory:
+    type: string
+
   vsix-file:
     type: string

--- a/unpublish/action.yaml
+++ b/unpublish/action.yaml
@@ -144,7 +144,7 @@ inputs:
 
       - Defaults to `vss-extension.json` if not specified
       - Can specify multiple manifest files
-      - Patterns are relative to the current working directory
+      - Patterns are relative to `working-directory` when specified, otherwise the current working directory
       - For install/share/unpublish/unshare/wait-for-validation/query-version:
         used as fallback source for publisher-id and extension-id when not specified
 
@@ -154,6 +154,20 @@ inputs:
       manifests/dev/vss-extension.json
       manifests/prod/vss-extension.json
       ```
+    required: false
+  working-directory:
+    description: |-
+      **Working directory** used as the base path for manifest-based operations.
+
+      Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
+      Required for: none.
+      Default: current working directory
+
+      - Manifest discovery and `manifest-file` patterns are resolved from this directory
+      - Use this when your extension manifest lives in a subfolder
+      - If not specified, the current working directory is used
+
+      **Example:** `tests/sample-extension`
     required: false
   vsix-file:
     description: |-
@@ -184,4 +198,5 @@ runs:
         publisher-id: ${{ inputs.publisher-id }}
         extension-id: ${{ inputs.extension-id }}
         manifest-file: ${{ inputs.manifest-file }}
+        working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}

--- a/unshare/README.md
+++ b/unshare/README.md
@@ -43,6 +43,17 @@ Unshare an Azure DevOps extension from specific organizations.
       old-org-2
 ```
 
+### Unshare Using Manifest Identity Fallback from a Subfolder
+
+```yaml
+- uses: jessehouwing/azdo-marketplace/unshare@v6
+  with:
+    token: ${{ secrets.MARKETPLACE_TOKEN }}
+    working-directory: './extension'
+    manifest-file: 'vss-extension.json'
+    accounts: 'old-org'
+```
+
 ### With OIDC Authentication
 
 ```yaml
@@ -70,6 +81,7 @@ Unshare an Azure DevOps extension from specific organizations.
 Identity (choose one):
 
 - `publisher-id` + `extension-id`
+- `manifest-file` (with optional `working-directory`) as a fallback source for identity metadata
 - `vsix-file` (fallback source for identity metadata)
 
 OR
@@ -89,6 +101,8 @@ OR
 
 #### Identity Fallback
 
+- `manifest-file`: Manifest path(s) used to infer `publisher-id` and `extension-id` when omitted
+- `working-directory`: Base directory for `manifest-file` when manifests live in a subfolder
 - `vsix-file`: Path to VSIX file used to infer `publisher-id` and `extension-id` when omitted
 
 ## Outputs
@@ -140,6 +154,8 @@ jobs:
 - `publisher-id`: Identifies the publisher that owns the extension to unshare.
 - `extension-id`: Identifies the extension to unshare.
 - `vsix-file`: Provides VSIX-based identity fallback when publisher/extension IDs are omitted.
+- `manifest-file`: Provides manifest-based identity fallback when publisher/extension IDs are omitted.
+- `working-directory`: Sets the base path used to resolve `manifest-file` in subfolder-based layouts.
 - `accounts`: Lists organizations/accounts to remove extension access from.
 
 ## GitHub Marketplace outputs

--- a/unshare/action.schema.yaml
+++ b/unshare/action.schema.yaml
@@ -43,6 +43,9 @@ inputs:
     items:
       type: string
 
+  working-directory:
+    type: string
+
   vsix-file:
     type: string
 

--- a/unshare/action.yaml
+++ b/unshare/action.yaml
@@ -144,7 +144,7 @@ inputs:
 
       - Defaults to `vss-extension.json` if not specified
       - Can specify multiple manifest files
-      - Patterns are relative to the current working directory
+      - Patterns are relative to `working-directory` when specified, otherwise the current working directory
       - For install/share/unpublish/unshare/wait-for-validation/query-version:
         used as fallback source for publisher-id and extension-id when not specified
 
@@ -154,6 +154,20 @@ inputs:
       manifests/dev/vss-extension.json
       manifests/prod/vss-extension.json
       ```
+    required: false
+  working-directory:
+    description: |-
+      **Working directory** used as the base path for manifest-based operations.
+
+      Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
+      Required for: none.
+      Default: current working directory
+
+      - Manifest discovery and `manifest-file` patterns are resolved from this directory
+      - Use this when your extension manifest lives in a subfolder
+      - If not specified, the current working directory is used
+
+      **Example:** `tests/sample-extension`
     required: false
   vsix-file:
     description: |-
@@ -209,5 +223,6 @@ runs:
         publisher-id: ${{ inputs.publisher-id }}
         extension-id: ${{ inputs.extension-id }}
         manifest-file: ${{ inputs.manifest-file }}
+        working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}
         accounts: ${{ inputs.accounts }}

--- a/wait-for-installation/README.md
+++ b/wait-for-installation/README.md
@@ -24,6 +24,19 @@ Verify that an Azure DevOps extension has been installed correctly and that all 
     manifest-file: './extension/vss-extension.json'
 ```
 
+### Verify with a Manifest in a Subfolder
+
+```yaml
+- uses: jessehouwing/azdo-marketplace/wait-for-installation@v6
+  with:
+    token: ${{ secrets.MARKETPLACE_TOKEN }}
+    publisher-id: 'my-publisher'
+    extension-id: 'my-extension'
+    accounts: 'myorg'
+    working-directory: './extension'
+    manifest-file: 'vss-extension.json'
+```
+
 ### Verify with VSIX
 
 ```yaml
@@ -113,6 +126,7 @@ Identity inputs:
 
 - `expected-tasks`: JSON array of expected tasks
 - `manifest-file`: Extension manifest path(s), newline-separated
+- `working-directory`: Base directory for `manifest-file` when manifests live in a subfolder
 - `vsix-file`: Path to .vsix file
 
 OR
@@ -236,6 +250,7 @@ Each task can have multiple versions. The verification succeeds if ALL specified
 - `accounts`: Lists organizations/accounts where installation is verified.
 - `expected-tasks`: Supplies explicit JSON task/version expectations.
 - `manifest-file`: Supplies manifest file(s) for task expectation discovery.
+- `working-directory`: Sets the base path used to resolve `manifest-file` in subfolder-based layouts.
 - `vsix-file`: Supplies a VSIX path for task expectation and identity discovery.
 - `timeout-minutes`: Sets total verification timeout window.
 - `polling-interval-seconds`: Sets interval between installation checks.

--- a/wait-for-installation/action.schema.yaml
+++ b/wait-for-installation/action.schema.yaml
@@ -40,6 +40,9 @@ inputs:
     items:
       type: string
 
+  working-directory:
+    type: string
+
   expected-tasks:
     type: string
     separators: newline

--- a/wait-for-installation/action.yaml
+++ b/wait-for-installation/action.yaml
@@ -167,7 +167,7 @@ inputs:
 
       - Defaults to `vss-extension.json` if not specified
       - Can specify multiple manifest files
-      - Patterns are relative to the current working directory
+      - Patterns are relative to `working-directory` when specified, otherwise the current working directory
       - For install/share/unpublish/unshare/wait-for-validation/query-version:
         used as fallback source for publisher-id and extension-id when not specified
 
@@ -177,6 +177,20 @@ inputs:
       manifests/dev/vss-extension.json
       manifests/prod/vss-extension.json
       ```
+    required: false
+  working-directory:
+    description: |-
+      **Working directory** used as the base path for manifest-based operations.
+
+      Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
+      Required for: none.
+      Default: current working directory
+
+      - Manifest discovery and `manifest-file` patterns are resolved from this directory
+      - Use this when your extension manifest lives in a subfolder
+      - If not specified, the current working directory is used
+
+      **Example:** `tests/sample-extension`
     required: false
   vsix-file:
     description: |-
@@ -238,6 +252,7 @@ runs:
         accounts: ${{ inputs.accounts }}
         expected-tasks: ${{ inputs.expected-tasks }}
         manifest-file: ${{ inputs.manifest-file }}
+        working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}
         timeout-minutes: ${{ inputs.timeout-minutes }}
         polling-interval-seconds: ${{ inputs.polling-interval-seconds }}

--- a/wait-for-validation/README.md
+++ b/wait-for-validation/README.md
@@ -36,6 +36,16 @@ Validate that an Azure DevOps extension has been successfully processed by the m
     vsix-file: ${{ steps.package.outputs.vsix-file }}
 ```
 
+### Validate Using Manifest Identity Fallback from a Subfolder
+
+```yaml
+- uses: jessehouwing/azdo-marketplace/wait-for-validation@v6
+  with:
+    token: ${{ secrets.MARKETPLACE_TOKEN }}
+    working-directory: './extension'
+    manifest-file: 'vss-extension.json'
+```
+
 ### With OIDC Authentication
 
 ```yaml
@@ -61,6 +71,7 @@ Validate that an Azure DevOps extension has been successfully processed by the m
 Identity (choose one):
 
 - `publisher-id` + `extension-id`
+- `manifest-file` (with optional `working-directory`) as a fallback source for identity metadata
 - `vsix-file` (fallback source for identity metadata)
 
 OR
@@ -86,6 +97,8 @@ OR
 
 #### Identity Fallback
 
+- `manifest-file`: Manifest path(s) used to infer `publisher-id` and `extension-id` when omitted
+- `working-directory`: Base directory for `manifest-file` when manifests live in a subfolder
 - `vsix-file`: Path to VSIX file used to infer `publisher-id` and `extension-id` when omitted
 
 ## Outputs
@@ -153,6 +166,8 @@ This action polls the marketplace to check if your extension has been successful
 - `extension-id`: Identifies the extension to validate.
 - `extension-version`: Targets a specific extension version for validation checks.
 - `vsix-file`: Provides VSIX-based identity fallback when publisher/extension IDs are omitted.
+- `manifest-file`: Provides manifest-based identity fallback when publisher/extension IDs are omitted.
+- `working-directory`: Sets the base path used to resolve `manifest-file` in subfolder-based layouts.
 - `timeout-minutes`: Sets total wait time for validation in minutes (default: `10`).
 - `polling-interval-seconds`: Sets polling interval between validation checks in seconds (default: `30`).
 

--- a/wait-for-validation/action.schema.yaml
+++ b/wait-for-validation/action.schema.yaml
@@ -46,6 +46,9 @@ inputs:
     items:
       type: string
 
+  working-directory:
+    type: string
+
   vsix-file:
     type: string
 

--- a/wait-for-validation/action.yaml
+++ b/wait-for-validation/action.yaml
@@ -157,7 +157,7 @@ inputs:
 
       - Defaults to `vss-extension.json` if not specified
       - Can specify multiple manifest files
-      - Patterns are relative to the current working directory
+      - Patterns are relative to `working-directory` when specified, otherwise the current working directory
       - For install/share/unpublish/unshare/wait-for-validation/query-version:
         used as fallback source for publisher-id and extension-id when not specified
 
@@ -167,6 +167,20 @@ inputs:
       manifests/dev/vss-extension.json
       manifests/prod/vss-extension.json
       ```
+    required: false
+  working-directory:
+    description: |-
+      **Working directory** used as the base path for manifest-based operations.
+
+      Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
+      Required for: none.
+      Default: current working directory
+
+      - Manifest discovery and `manifest-file` patterns are resolved from this directory
+      - Use this when your extension manifest lives in a subfolder
+      - If not specified, the current working directory is used
+
+      **Example:** `tests/sample-extension`
     required: false
   vsix-file:
     description: |-
@@ -228,6 +242,7 @@ runs:
         extension-id: ${{ inputs.extension-id }}
         extension-version: ${{ inputs.extension-version }}
         manifest-file: ${{ inputs.manifest-file }}
+        working-directory: ${{ inputs.working-directory }}
         timeout-minutes: ${{ inputs.timeout-minutes }}
         polling-interval-seconds: ${{ inputs.polling-interval-seconds }}
         vsix-file: ${{ inputs.vsix-file }}


### PR DESCRIPTION
This pull request introduces support for a new `working-directory` input for manifest-based operations in both GitHub Actions and Azure Pipelines. This enhancement allows users to specify a base directory for extension manifests, making workflows more flexible when manifests are located in subfolders. Documentation and schema files have been updated to reflect this new input, and usage examples have been provided.

Manifest-based operations improvements:

* Added `working-directory` input to action schemas (`action.schema.yaml`, `action.yml`), allowing manifest discovery and patterns to be resolved relative to the specified directory. [[1]](diffhunk://#diff-3215daeec24ae0a5192a337c62f3e6bd6cbe58200648d03b5dbd7d8b4d16e9e6R71-R73) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R177-R190)
* Updated documentation for GitHub Actions and Azure Pipelines to describe the new `working-directory` input, its purpose, and usage scenarios, including examples. [[1]](diffhunk://#diff-91ce3953cfd5f651329f9989dfbe262d19ceea4229d0d1d03c5f31317391b018R48) [[2]](diffhunk://#diff-91ce3953cfd5f651329f9989dfbe262d19ceea4229d0d1d03c5f31317391b018L79-R80) [[3]](diffhunk://#diff-91ce3953cfd5f651329f9989dfbe262d19ceea4229d0d1d03c5f31317391b018L94-R95) [[4]](diffhunk://#diff-91ce3953cfd5f651329f9989dfbe262d19ceea4229d0d1d03c5f31317391b018L105-R106) [[5]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432R53) [[6]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L78-R79) [[7]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L96-R97) [[8]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L113-R114) [[9]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L126-R127) [[10]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L139-R140) [[11]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L152-R153) [[12]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L181-R182) [[13]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L193-R194) [[14]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432R212-R229) [[15]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R10-R15)
* Clarified that `manifest-file` patterns are resolved from `working-directory` when specified, otherwise from the current working directory, in both documentation and input descriptions. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L166-R166) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R103)

Usage examples and workflow updates:

* Added and updated workflow and README examples to show how to use `working-directory` for operations such as `package`, `publish`, `install`, `share`, `unshare`, `unpublish`, `wait-for-validation`, and `query-version`. [[1]](diffhunk://#diff-d9660c15b8187fb4cb46842cc88a9876172ee6fde0e8bcf26cf83d0770896ac4R94) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R160) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R174) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R184) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R195) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R206) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R217) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R243-R244) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R256) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R269)

Documentation structure improvements:

* Refactored input documentation in `README.md` for clarity, using section headings instead of bold labels and grouping related inputs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R103) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R144)

These changes make it easier to work with extension manifests located in subfolders and improve documentation for users configuring marketplace operations.