### PR TITLE
Release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For manifest-based operations, `manifest-file` patterns are resolved from `worki
 - `auth-type`: Chooses authentication mode (`pat`, `basic`, `oidc`) for authenticated operations.
 - `service-url`: Overrides the Azure DevOps/Marketplace endpoint for supported operations.
 - `token`: Provides the secret token used for `pat` and `basic` authentication.
-- `tfx-version`: Selects the `tfx-cli` source (`built-in`, `path`, or npm version spec); `built-in` uses the bundled vesion, while `path` uses `tfx` from PATH.
+- `tfx-version`: Selects the `tfx-cli` source (`built-in`, `path`, or npm version spec); `built-in` uses the bundled version, while `path` uses `tfx` from PATH.
 - `username`: Provides the username when `auth-type` is `basic`.
 
 #### Extension Identity

--- a/Scripts/bundle.mjs
+++ b/Scripts/bundle.mjs
@@ -434,6 +434,69 @@ function runCommand(command, args, cwd) {
   });
 }
 
+function runCommandForOutput(command, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+
+      const detail = stderr.trim() || stdout.trim();
+      reject(
+        new Error(
+          `Command failed (${code}): ${command} ${args.join(' ')}${detail ? `\n${detail}` : ''}`
+        )
+      );
+    });
+  });
+}
+
+async function getChangedFilesInDirectory(directory) {
+  const relativeDirectory = path.relative(rootDir, directory) || '.';
+  const output = await runCommandForOutput(
+    'git',
+    ['status', '--porcelain=v1', '--untracked-files=all', '--', relativeDirectory],
+    rootDir
+  );
+
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => {
+      const pathText = line.slice(3);
+      const resolvedPath = pathText.includes(' -> ') ? pathText.split(' -> ').at(-1) : pathText;
+      return path.resolve(rootDir, resolvedPath);
+    })
+    .filter((fullPath) => {
+      const relativeToDirectory = path.relative(directory, fullPath);
+      return (
+        relativeToDirectory &&
+        !relativeToDirectory.startsWith('..') &&
+        !path.isAbsolute(relativeToDirectory)
+      );
+    });
+}
+
 const runtimeNpmFlags = [
   '--omit=dev',
   '--omit=optional',
@@ -516,7 +579,7 @@ async function dedupeRuntimeDependencies(target) {
   await runCommand(npmCommand, dedupeArgs, distDir);
 }
 
-async function normalizeTextLineEndings(directory, { skipDirectories = new Set() } = {}) {
+async function normalizeTextLineEndings(directory) {
   const textExtensions = new Set([
     '.js',
     '.mjs',
@@ -546,44 +609,30 @@ async function normalizeTextLineEndings(directory, { skipDirectories = new Set()
     return;
   }
 
-  const stack = [directory];
+  const changedFiles = await getChangedFilesInDirectory(directory);
 
-  while (stack.length > 0) {
-    const current = stack.pop();
-    if (!current) {
+  for (const fullPath of changedFiles) {
+    if (!(await pathExists(fullPath))) {
       continue;
     }
 
-    const entries = await fs.readdir(current, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = path.join(current, entry.name);
+    // Skip files with extensions that are never text to avoid unnecessary reads.
+    const ext = path.extname(fullPath).toLowerCase();
+    if (ext && !textExtensions.has(ext)) {
+      continue;
+    }
 
-      if (entry.isDirectory()) {
-        stack.push(fullPath);
-        continue;
-      }
+    const content = await fs.readFile(fullPath);
 
-      if (!entry.isFile()) {
-        continue;
-      }
+    // Skip likely binary files.
+    if (content.includes(0)) {
+      continue;
+    }
 
-      // Skip files with extensions that are never text to avoid unnecessary reads.
-      const ext = path.extname(entry.name).toLowerCase();
-      if (ext && !textExtensions.has(ext)) {
-        continue;
-      }
-
-      const content = await fs.readFile(fullPath);
-
-      // Skip likely binary files.
-      if (content.includes(0)) {
-        continue;
-      }
-
-      const normalized = content.toString('utf8').replace(/\r\n/g, '\n');
-      if (normalized !== content.toString('utf8')) {
-        await fs.writeFile(fullPath, normalized, 'utf8');
-      }
+    const text = content.toString('utf8');
+    const normalized = text.replace(/\r\n/g, '\n');
+    if (normalized !== text) {
+      await fs.writeFile(fullPath, normalized, 'utf8');
     }
   }
 }

--- a/action.yml
+++ b/action.yml
@@ -180,7 +180,7 @@ inputs:
 
       Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
       Required for: none.
-      Default: current working directory
+      Default: none
 
       - Manifest discovery and `manifest-file` patterns are resolved from this directory
       - Use this when your extension manifest lives in a subfolder
@@ -570,3 +570,4 @@ outputs:
 runs:
   using: node24
   main: packages/github-action/dist/bundle.js
+

--- a/action.yml
+++ b/action.yml
@@ -570,4 +570,3 @@ outputs:
 runs:
   using: node24
   main: packages/github-action/dist/bundle.js
-

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -139,7 +139,7 @@ inputs:
 
       Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
       Required for: none.
-      Default: current working directory
+      Default: none
 
       - Manifest discovery and `manifest-file` patterns are resolved from this directory
       - Use this when your extension manifest lives in a subfolder
@@ -203,3 +203,4 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}
         accounts: ${{ inputs.accounts }}
+

--- a/install/action.yaml
+++ b/install/action.yaml
@@ -203,4 +203,3 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}
         accounts: ${{ inputs.accounts }}
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -5384,9 +5384,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.3.tgz",
-      "integrity": "sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
       "funding": [
         {
           "type": "github",
@@ -5399,9 +5399,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.2.tgz",
-      "integrity": "sha512-kA6Txdt1cHsk+/qWKuV1jZUHBD6QUXWKhWVBuSmfP5YElW5HvJ/yC7eFCS+DQg7LphBPuUoEBMQ+m1z6UlF24w==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
+      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
       "funding": [
         {
           "type": "github",
@@ -5410,7 +5410,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.1.1",
+        "fast-xml-builder": "^1.1.4",
         "path-expression-matcher": "^1.1.3",
         "strnum": "^2.1.2"
       },

--- a/package/action.yaml
+++ b/package/action.yaml
@@ -281,4 +281,3 @@ runs:
         bypass-validation: ${{ inputs.bypass-validation }}
         update-tasks-version: ${{ inputs.update-tasks-version }}
         update-tasks-id: ${{ inputs.update-tasks-id }}
-

--- a/package/action.yaml
+++ b/package/action.yaml
@@ -80,7 +80,7 @@ inputs:
 
       Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
       Required for: none.
-      Default: current working directory
+      Default: none
 
       - Manifest discovery and `manifest-file` patterns are resolved from this directory
       - Use this when your extension manifest lives in a subfolder
@@ -281,3 +281,4 @@ runs:
         bypass-validation: ${{ inputs.bypass-validation }}
         update-tasks-version: ${{ inputs.update-tasks-version }}
         update-tasks-id: ${{ inputs.update-tasks-id }}
+

--- a/packages/core/src/__tests__/wait-for-installation.test.ts
+++ b/packages/core/src/__tests__/wait-for-installation.test.ts
@@ -16,6 +16,7 @@ const getPersonalAccessTokenHandlerMock = jest.fn((token: string) => {
 
 const readManifestMock = jest.fn<() => Promise<any>>();
 const resolveTaskManifestPathsMock = jest.fn<() => string[]>();
+const resolveManifestPathsMock = jest.fn<() => Promise<string[]>>();
 
 const vsixReaderCloseMock = jest.fn<() => Promise<void>>();
 const vsixReaderGetTasksInfoMock =
@@ -32,6 +33,7 @@ jest.unstable_mockModule('azure-devops-node-api', () => ({
 jest.unstable_mockModule('../manifest-utils.js', () => ({
   readManifest: readManifestMock,
   resolveTaskManifestPaths: resolveTaskManifestPathsMock,
+  resolveManifestPaths: resolveManifestPathsMock,
 }));
 
 jest.unstable_mockModule('../vsix-reader.js', () => ({
@@ -107,6 +109,7 @@ describe('waitForInstallation', () => {
   });
 
   it('resolves expected tasks from manifestFiles and verifies versions', async () => {
+    resolveManifestPathsMock.mockResolvedValue(['vss-extension.json']);
     readManifestMock
       .mockResolvedValueOnce({
         contributes: [{ type: 'ms.vss-distributed-task.task', properties: { name: 'Task1' } }],
@@ -143,6 +146,7 @@ describe('waitForInstallation', () => {
   });
 
   it('resolves tasks across multiple manifest files and verifies all referenced task versions', async () => {
+    resolveManifestPathsMock.mockResolvedValue(['vss-extension.a.json', 'vss-extension.b.json']);
     readManifestMock
       .mockResolvedValueOnce({
         contributes: [{ type: 'ms.vss-distributed-task.task', properties: { name: 'TaskA' } }],
@@ -400,6 +404,7 @@ describe('waitForInstallation', () => {
   });
 
   it('falls back when individual task manifest read fails', async () => {
+    resolveManifestPathsMock.mockResolvedValue(['vss-extension.json']);
     readManifestMock
       .mockResolvedValueOnce({
         contributes: [{ type: 'ms.vss-distributed-task.task', properties: { name: 'Task1' } }],
@@ -430,6 +435,55 @@ describe('waitForInstallation', () => {
     expect(platform.warningMessages.some((m) => m.includes('Failed to read task manifest'))).toBe(
       true
     );
+  });
+
+  it('throws when manifestFiles patterns resolve to empty list and no vsixFile is available', async () => {
+    resolveManifestPathsMock.mockResolvedValue([]);
+
+    await expect(
+      waitForInstallation(
+        {
+          publisherId: 'pub',
+          extensionId: 'ext',
+          accounts: ['https://dev.azure.com/org1'],
+          manifestFiles: ['no-match-*.json'],
+          rootFolder: '/some/root',
+        },
+        auth,
+        platform
+      )
+    ).rejects.toThrow("no files matched patterns [no-match-*.json] in '/some/root'");
+
+    expect(platform.warningMessages.some((m) => m.includes('no-match-*.json'))).toBe(true);
+    expect(platform.warningMessages.some((m) => m.includes('/some/root'))).toBe(true);
+  });
+
+  it('warns and falls through to vsixFile when manifestFiles patterns resolve to empty list', async () => {
+    resolveManifestPathsMock.mockResolvedValue([]);
+    vsixReaderGetTasksInfoMock.mockResolvedValue([{ name: 'TaskFromVsix', version: '1.0.0' }]);
+    getTaskDefinitionsMock.mockResolvedValue([
+      {
+        name: 'TaskFromVsix',
+        id: 'task-vsix',
+        version: { major: 1, minor: 0, patch: 0 },
+      },
+    ]);
+
+    const result = await waitForInstallation(
+      {
+        publisherId: 'pub',
+        extensionId: 'ext',
+        accounts: ['https://dev.azure.com/org1'],
+        manifestFiles: ['no-match-*.json'],
+        vsixFile: 'extension.vsix',
+      },
+      auth,
+      platform
+    );
+
+    expect(result.success).toBe(true);
+    expect(platform.warningMessages.some((m) => m.includes('no-match-*.json'))).toBe(true);
+    expect(vsixReaderOpenMock).toHaveBeenCalledWith('extension.vsix');
   });
 
   it('does not require auth.serviceUrl and uses account URLs instead', async () => {

--- a/packages/core/src/commands/wait-for-installation.ts
+++ b/packages/core/src/commands/wait-for-installation.ts
@@ -65,7 +65,7 @@ async function resolveExpectedTasks(
   if (options.manifestFiles && options.manifestFiles.length > 0) {
     try {
       platform.debug(`Reading task versions from ${options.manifestFiles.length} manifest file(s)`);
-      const rootFolder = options.rootFolder ?? cwd();
+      const rootFolder = options.rootFolder || cwd();
       const manifestFiles = await resolveManifestPaths(rootFolder, options.manifestFiles, platform);
 
       const expectedByTask = new Map<string, Set<string>>();

--- a/packages/core/src/commands/wait-for-installation.ts
+++ b/packages/core/src/commands/wait-for-installation.ts
@@ -63,52 +63,66 @@ async function resolveExpectedTasks(
 
   // If manifestFiles are provided, read task versions from all manifests
   if (options.manifestFiles && options.manifestFiles.length > 0) {
-    try {
-      platform.debug(`Reading task versions from ${options.manifestFiles.length} manifest file(s)`);
-      const rootFolder = options.rootFolder || cwd();
-      const manifestFiles = await resolveManifestPaths(rootFolder, options.manifestFiles, platform);
+    platform.debug(`Reading task versions from ${options.manifestFiles.length} manifest file(s)`);
+    const rootFolder = options.rootFolder || cwd();
+    const manifestFiles = await resolveManifestPaths(rootFolder, options.manifestFiles, platform);
 
-      const expectedByTask = new Map<string, Set<string>>();
+    if (manifestFiles.length === 0) {
+      const patternsStr = options.manifestFiles.join(', ');
+      platform.warning(
+        `No manifest files found matching patterns [${patternsStr}] in '${rootFolder}'.`
+      );
+      if (!options.vsixFile) {
+        throw new Error(
+          `manifestFiles was provided but no files matched patterns [${patternsStr}] in '${rootFolder}'. ` +
+            `Provide valid manifest file patterns, a vsixFile, or use expectedTasks directly.`
+        );
+      }
+      // vsixFile is available as fallback; fall through to the vsixFile block below
+    } else {
+      try {
+        const expectedByTask = new Map<string, Set<string>>();
 
-      for (const manifestFile of manifestFiles) {
-        try {
-          const manifest = (await readManifest(manifestFile, platform)) as ExtensionManifest;
-          const taskPaths = resolveTaskManifestPaths(manifest, manifestFile, platform);
+        for (const manifestFile of manifestFiles) {
+          try {
+            const manifest = (await readManifest(manifestFile, platform)) as ExtensionManifest;
+            const taskPaths = resolveTaskManifestPaths(manifest, manifestFile, platform);
 
-          for (const taskPath of taskPaths) {
-            try {
-              const taskManifest = (await readManifest(taskPath, platform)) as any;
-              if (taskManifest.name && taskManifest.version) {
-                const version = `${taskManifest.version.Major}.${taskManifest.version.Minor}.${taskManifest.version.Patch}`;
-                const existing =
-                  expectedByTask.get(taskManifest.name as string) ?? new Set<string>();
-                existing.add(version);
-                expectedByTask.set(taskManifest.name as string, existing);
-                platform.debug(`Found task ${taskManifest.name} v${version}`);
+            for (const taskPath of taskPaths) {
+              try {
+                const taskManifest = (await readManifest(taskPath, platform)) as any;
+                if (taskManifest.name && taskManifest.version) {
+                  const version = `${taskManifest.version.Major}.${taskManifest.version.Minor}.${taskManifest.version.Patch}`;
+                  const existing =
+                    expectedByTask.get(taskManifest.name as string) ?? new Set<string>();
+                  existing.add(version);
+                  expectedByTask.set(taskManifest.name as string, existing);
+                  platform.debug(`Found task ${taskManifest.name} v${version}`);
+                }
+              } catch (error: unknown) {
+                const errorMessage = error instanceof Error ? error.message : String(error);
+                platform.warning(`Failed to read task manifest ${taskPath}: ${errorMessage}`);
               }
-            } catch (error: unknown) {
-              const errorMessage = error instanceof Error ? error.message : String(error);
-              platform.warning(`Failed to read task manifest ${taskPath}: ${errorMessage}`);
             }
+          } catch (error: unknown) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            platform.warning(`Failed to read manifest ${manifestFile}: ${errorMessage}`);
           }
-        } catch (error: unknown) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
-          platform.warning(`Failed to read manifest ${manifestFile}: ${errorMessage}`);
         }
-      }
 
-      const tasks: ExpectedTask[] = [...expectedByTask.entries()].map(([name, versions]) => ({
-        name,
-        versions: [...versions],
-      }));
+        const tasks: ExpectedTask[] = [...expectedByTask.entries()].map(([name, versions]) => ({
+          name,
+          versions: [...versions],
+        }));
 
-      if (tasks.length > 0) {
-        platform.debug(`Resolved ${tasks.length} task(s) from manifest file(s)`);
-        return tasks;
+        if (tasks.length > 0) {
+          platform.debug(`Resolved ${tasks.length} task(s) from manifest file(s)`);
+          return tasks;
+        }
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        platform.warning(`Failed to resolve tasks from manifest files: ${errorMessage}`);
       }
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      platform.warning(`Failed to resolve tasks from manifest files: ${errorMessage}`);
     }
   }
 

--- a/publish/action.yaml
+++ b/publish/action.yaml
@@ -174,7 +174,7 @@ inputs:
 
       Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
       Required for: none.
-      Default: current working directory
+      Default: none
 
       - Manifest discovery and `manifest-file` patterns are resolved from this directory
       - Use this when your extension manifest lives in a subfolder
@@ -395,3 +395,4 @@ runs:
         no-wait-validation: ${{ inputs.no-wait-validation }}
         update-tasks-version: ${{ inputs.update-tasks-version }}
         update-tasks-id: ${{ inputs.update-tasks-id }}
+

--- a/publish/action.yaml
+++ b/publish/action.yaml
@@ -395,4 +395,3 @@ runs:
         no-wait-validation: ${{ inputs.no-wait-validation }}
         update-tasks-version: ${{ inputs.update-tasks-version }}
         update-tasks-id: ${{ inputs.update-tasks-id }}
-

--- a/query-version/action.yaml
+++ b/query-version/action.yaml
@@ -219,7 +219,7 @@ inputs:
 
       Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
       Required for: none.
-      Default: current working directory
+      Default: none
 
       - Manifest discovery and `manifest-file` patterns are resolved from this directory
       - Use this when your extension manifest lives in a subfolder
@@ -292,3 +292,4 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         use: ${{ inputs.use }}
         vsix-file: ${{ inputs.vsix-file }}
+

--- a/query-version/action.yaml
+++ b/query-version/action.yaml
@@ -292,4 +292,3 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         use: ${{ inputs.use }}
         vsix-file: ${{ inputs.vsix-file }}
-

--- a/share/action.yaml
+++ b/share/action.yaml
@@ -226,4 +226,3 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}
         accounts: ${{ inputs.accounts }}
-

--- a/share/action.yaml
+++ b/share/action.yaml
@@ -161,7 +161,7 @@ inputs:
 
       Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
       Required for: none.
-      Default: current working directory
+      Default: none
 
       - Manifest discovery and `manifest-file` patterns are resolved from this directory
       - Use this when your extension manifest lives in a subfolder
@@ -226,3 +226,4 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}
         accounts: ${{ inputs.accounts }}
+

--- a/unpublish/action.yaml
+++ b/unpublish/action.yaml
@@ -161,7 +161,7 @@ inputs:
 
       Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
       Required for: none.
-      Default: current working directory
+      Default: none
 
       - Manifest discovery and `manifest-file` patterns are resolved from this directory
       - Use this when your extension manifest lives in a subfolder
@@ -200,3 +200,4 @@ runs:
         manifest-file: ${{ inputs.manifest-file }}
         working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}
+

--- a/unpublish/action.yaml
+++ b/unpublish/action.yaml
@@ -200,4 +200,3 @@ runs:
         manifest-file: ${{ inputs.manifest-file }}
         working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}
-

--- a/unshare/action.yaml
+++ b/unshare/action.yaml
@@ -226,4 +226,3 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}
         accounts: ${{ inputs.accounts }}
-

--- a/unshare/action.yaml
+++ b/unshare/action.yaml
@@ -161,7 +161,7 @@ inputs:
 
       Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
       Required for: none.
-      Default: current working directory
+      Default: none
 
       - Manifest discovery and `manifest-file` patterns are resolved from this directory
       - Use this when your extension manifest lives in a subfolder
@@ -226,3 +226,4 @@ runs:
         working-directory: ${{ inputs.working-directory }}
         vsix-file: ${{ inputs.vsix-file }}
         accounts: ${{ inputs.accounts }}
+

--- a/wait-for-installation/action.yaml
+++ b/wait-for-installation/action.yaml
@@ -184,7 +184,7 @@ inputs:
 
       Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
       Required for: none.
-      Default: current working directory
+      Default: none
 
       - Manifest discovery and `manifest-file` patterns are resolved from this directory
       - Use this when your extension manifest lives in a subfolder
@@ -256,3 +256,4 @@ runs:
         vsix-file: ${{ inputs.vsix-file }}
         timeout-minutes: ${{ inputs.timeout-minutes }}
         polling-interval-seconds: ${{ inputs.polling-interval-seconds }}
+

--- a/wait-for-installation/action.yaml
+++ b/wait-for-installation/action.yaml
@@ -256,4 +256,3 @@ runs:
         vsix-file: ${{ inputs.vsix-file }}
         timeout-minutes: ${{ inputs.timeout-minutes }}
         polling-interval-seconds: ${{ inputs.polling-interval-seconds }}
-

--- a/wait-for-validation/action.yaml
+++ b/wait-for-validation/action.yaml
@@ -174,7 +174,7 @@ inputs:
 
       Available for: install, package, publish, query-version, share, unpublish, unshare, wait-for-installation, wait-for-validation.
       Required for: none.
-      Default: current working directory
+      Default: none
 
       - Manifest discovery and `manifest-file` patterns are resolved from this directory
       - Use this when your extension manifest lives in a subfolder
@@ -246,3 +246,4 @@ runs:
         timeout-minutes: ${{ inputs.timeout-minutes }}
         polling-interval-seconds: ${{ inputs.polling-interval-seconds }}
         vsix-file: ${{ inputs.vsix-file }}
+

--- a/wait-for-validation/action.yaml
+++ b/wait-for-validation/action.yaml
@@ -246,4 +246,3 @@ runs:
         timeout-minutes: ${{ inputs.timeout-minutes }}
         polling-interval-seconds: ${{ inputs.polling-interval-seconds }}
         vsix-file: ${{ inputs.vsix-file }}
-


### PR DESCRIPTION
This pull request introduces support for specifying a `working-directory` input for manifest-based operations in both GitHub Actions and Azure Pipelines. This allows users to run extension packaging, publishing, and related commands from subfolders, making it easier to manage projects with manifests in non-root directories. The documentation and schema have been updated to reflect this new capability, including usage examples and clarifications on how manifest file patterns are resolved.

**Key changes:**

**Feature: Add `working-directory` support for manifest-based operations**
- Added a new `working-directory` input to the action schema (`action.schema.yaml`), input documentation (`action.yml`), and workflow usage (`.github/workflows/release-test-github-actions.yml`). This input sets the base directory for manifest-based operations, ensuring manifest file patterns are resolved relative to this directory when specified. [[1]](diffhunk://#diff-3215daeec24ae0a5192a337c62f3e6bd6cbe58200648d03b5dbd7d8b4d16e9e6R71-R73) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L166-R166) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R177-R190) [[4]](diffhunk://#diff-d9660c15b8187fb4cb46842cc88a9876172ee6fde0e8bcf26cf83d0770896ac4R94)

**Documentation updates:**
- Updated the main README and provided detailed usage examples for `working-directory` across all relevant commands and scenarios, including package, publish, install, share, unshare, unpublish, wait-for-validation, and query-version. Clarified how manifest file patterns are resolved when `working-directory` is set or omitted. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R103) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R144) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R160) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R174) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R184) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R195) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R206) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R217) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R243-R244) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R256) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R269)
- Expanded documentation in `docs/README.md`, `docs/azure-pipelines.md`, and `docs/github-actions.md` to include `working-directory` as a supported input, with examples and explanations for both Azure Pipelines (`workingDirectory`) and GitHub Actions (`working-directory`). [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R10-R15) [[2]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432R53) [[3]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L78-R79) [[4]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L96-R97) [[5]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L113-R114) [[6]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L126-R127) [[7]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L139-R140) [[8]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L152-R153) [[9]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L181-R182) [[10]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432L193-R194) [[11]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432R212-R229) [[12]](diffhunk://#diff-91ce3953cfd5f651329f9989dfbe262d19ceea4229d0d1d03c5f31317391b018R48) [[13]](diffhunk://#diff-91ce3953cfd5f651329f9989dfbe262d19ceea4229d0d1d03c5f31317391b018L79-R80) [[14]](diffhunk://#diff-91ce3953cfd5f651329f9989dfbe262d19ceea4229d0d1d03c5f31317391b018L94-R95) [[15]](diffhunk://#diff-91ce3953cfd5f651329f9989dfbe262d19ceea4229d0d1d03c5f31317391b018L105-R106)

**Usability improvements:**
- Provided clear guidance on when and how to use the `working-directory` input, including default behaviors and when it is required, to help users avoid common pitfalls when working with manifests in subfolders. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R177-R190) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R62-R103) [[3]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432R212-R229)

These changes make it easier to use the action with monorepos or projects where extension manifests are not located at the repository root.