### PR TITLE
feat: add vsix-file-name output to GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       major: ${{ steps.parse.outputs.major }}
       minor: ${{ steps.parse.outputs.minor }}
       patch: ${{ steps.parse.outputs.patch }}
-      vsix-file: ${{ steps.package.outputs.vsix-file }}
+      vsix-file-name: ${{ steps.package.outputs.vsix-file-name }}
 
     steps:
       - name: Resolve version
@@ -241,7 +241,7 @@ jobs:
         with:
           auth-type: oidc
           use: vsix
-          vsix-file: ${{ runner.temp }}/vsix/${{ needs.prepare-release.outputs.vsix-file }}
+          vsix-file: ${{ runner.temp }}/vsix/${{ needs.prepare-release.outputs.vsix-file-name }}
           publisher-id: ${{ env.PUBLISHER_ID_DEV }}
           extension-id: ${{ env.EXTENSION_ID }}-preview
           extension-visibility: private_preview
@@ -398,7 +398,7 @@ jobs:
         with:
           auth-type: oidc
           use: vsix
-          vsix-file: ${{ runner.temp }}/vsix/*.vsix
+          vsix-file: ${{ runner.temp }}/vsix/${{ needs.prepare-release.outputs.vsix-file-name }}
           no-wait-validation: true
 
       - name: Wait for validation
@@ -446,7 +446,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_VERSION: v${{ needs.prepare-release.outputs.version }}
-          VSIX_FILE: ${{ runner.temp }}/vsix/${{ needs.prepare-release.outputs.vsix-file }}
+          VSIX_FILE: ${{ runner.temp }}/vsix/${{ needs.prepare-release.outputs.vsix-file-name }}
           GITHUB_REPOSITORY_NAME: ${{ github.repository }}
         shell: pwsh
         run: |

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ When creating a PAT for pipeline automation, include at least the following scop
     manifest-file: vss-extension.json
 
 - run: echo "VSIX: ${{ steps.publish.outputs.vsix-file }}"
+- run: echo "VSIX file name: ${{ steps.publish.outputs.vsix-file-name }}"
 ```
 
 ### Manifests in a subfolder
@@ -136,6 +137,7 @@ For manifest-based operations, `manifest-file` patterns are resolved from `worki
 #### Package / Publish
 
 - `vsix-file`: Returns path to the generated VSIX file.
+- `vsix-file-name`: Returns the generated VSIX filename (for example `publisher.extension-1.2.3.vsix`).
 
 #### Show
 
@@ -161,6 +163,7 @@ For manifest-based operations, `manifest-file` patterns are resolved from `worki
     manifest-file: vss-extension.json
 
 - run: echo "Packaged: ${{ steps.package.outputs.vsix-file }}"
+- run: echo "Packaged filename: ${{ steps.package.outputs.vsix-file-name }}"
 ```
 
 ### publish

--- a/action.schema.yaml
+++ b/action.schema.yaml
@@ -164,6 +164,9 @@ outputs:
   vsix-file:
     type: string
 
+  vsix-file-name:
+    type: string
+
   metadata:
     type: string
 

--- a/action.yml
+++ b/action.yml
@@ -532,6 +532,19 @@ outputs:
 
       - run: echo "VSIX at $``{{ steps.package.outputs.vsix-file }}"
       ```
+  vsix-file-name:
+    description: |
+      **Filename of generated .vsix file** (package/publish operations).
+
+      **Example usage:**
+      ```yaml
+      - uses: jessehouwing/azdo-marketplace@v6
+        id: package
+        with:
+          operation: package
+
+      - run: echo "VSIX file name $``{{ steps.package.outputs.vsix-file-name }}"
+      ```
   metadata:
     description: |
       **Extension metadata as JSON** (show operation only).

--- a/docs/azure-pipelines.md
+++ b/docs/azure-pipelines.md
@@ -232,12 +232,13 @@ When `workingDirectory` is omitted, manifest discovery falls back to the current
 Declared task output variables (from `task.json`):
 
 - `vsixFile`
+- `vsixFileName`
 - `extensionMetadata`
 - `proposedVersion` — highest version from all sources
 - `currentVersion` — resolved version before increment; when marketplace is queried this is the marketplace version, otherwise it falls back to the selected source version
 - `versionSource` — which source won: `marketplace`, `manifest`, `vsix`, or `literal`
 
-These are referenced as step outputs, for example `$(packageExt.vsixFile)`.
+These are referenced as step outputs, for example `$(packageExt.vsixFile)` and `$(packageExt.vsixFileName)`.
 
 ## queryVersion examples
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -199,7 +199,8 @@ When `working-directory` is omitted, manifest discovery falls back to the curren
 
 ## Unified action outputs
 
-- `vsix-file` (package)
+- `vsix-file` (package/publish)
+- `vsix-file-name` (package/publish)
 - `metadata` (show)
 - `proposed-version` (query-version) — highest version from all sources
 - `current-version` (query-version) — resolved version before increment (from the winning `version-source`)
@@ -239,6 +240,7 @@ Use these when you prefer a dedicated command surface over setting `operation` m
   id: package
 
 - run: echo "VSIX: ${{ steps.package.outputs.vsix-file }}"
+- run: echo "VSIX filename: ${{ steps.package.outputs.vsix-file-name }}"
 ```
 
 ## Recommended publish example (OIDC)

--- a/docs/migrate-azure-pipelines-v5-to-github-actions.md
+++ b/docs/migrate-azure-pipelines-v5-to-github-actions.md
@@ -192,6 +192,7 @@ v5 Azure Pipelines output references typically looked like pipeline variables.
 In GitHub Actions, consume step outputs instead:
 
 - package output: `${{ steps.package.outputs.vsix-file }}`
+- package filename output: `${{ steps.package.outputs.vsix-file-name }}`
 - show output: `${{ steps.show.outputs.metadata }}`
 - query version outputs: `${{ steps.version.outputs.proposed-version }}`, `${{ steps.version.outputs.current-version }}`
 

--- a/docs/migrate-azure-pipelines-v5-to-v6.md
+++ b/docs/migrate-azure-pipelines-v5-to-v6.md
@@ -234,9 +234,11 @@ In v6, `queryVersion` introduces multi-source version resolution:
 Azure Pipelines v6 task outputs:
 
 - `vsixFile`
+- `vsixFileName`
 - `extensionMetadata`
 - `proposedVersion`
 - `currentVersion`
+- `versionSource`
 
 If your v5 pipeline referenced legacy output variable names, update those references to the v6 names.
 

--- a/docs/migrate-azure-pipelines-v6-to-github-actions.md
+++ b/docs/migrate-azure-pipelines-v6-to-github-actions.md
@@ -163,6 +163,7 @@ GitHub Actions references:
 Typical output mapping:
 
 - Azure Pipelines `vsixFile` → GitHub Actions `vsix-file`
+- Azure Pipelines `vsixFileName` → GitHub Actions `vsix-file-name`
 - Azure Pipelines `extensionMetadata` → GitHub Actions `metadata`
 - Azure Pipelines `proposedVersion` → GitHub Actions `proposed-version`
 - Azure Pipelines `currentVersion` → GitHub Actions `current-version`
@@ -183,7 +184,7 @@ Legacy v5/v6 status-style task outputs are not used in GitHub Actions. Use built
 
 Use `${{ steps.<step_id>.conclusion }}` when `continue-on-error: true` is involved and you need post-step branching based on final conclusion semantics.
 
-Current Azure Pipelines v6 task outputs are `vsixFile`, `extensionMetadata`, `proposedVersion`, and `currentVersion`; status-style outputs are legacy and should not be relied on.
+Current Azure Pipelines v6 task outputs are `vsixFile`, `vsixFileName`, `extensionMetadata`, `proposedVersion`, `currentVersion`, and `versionSource`; status-style outputs are legacy and should not be relied on.
 
 ## End-to-end example
 

--- a/package/README.md
+++ b/package/README.md
@@ -95,6 +95,7 @@ None - all inputs are optional with sensible defaults.
 ## Outputs
 
 - `vsix-file`: Path to the generated .vsix file
+- `vsix-file-name`: Filename of the generated .vsix file
 
 ## Example: Complete Workflow
 
@@ -137,6 +138,7 @@ jobs:
     manifest-file: vss-extension.json
 
 - run: echo "VSIX: ${{ steps.package.outputs.vsix-file }}"
+- run: echo "VSIX filename: ${{ steps.package.outputs.vsix-file-name }}"
 ```
 
 ## GitHub Marketplace inputs
@@ -161,6 +163,7 @@ jobs:
 ## GitHub Marketplace outputs
 
 - `vsix-file`: Returns the full path to the generated VSIX file.
+- `vsix-file-name`: Returns the generated VSIX filename without the directory path.
 
 ## See Also
 

--- a/package/action.schema.yaml
+++ b/package/action.schema.yaml
@@ -81,3 +81,6 @@ inputs:
 outputs:
   vsix-file:
     type: string
+
+  vsix-file-name:
+    type: string

--- a/package/action.yaml
+++ b/package/action.yaml
@@ -258,6 +258,20 @@ outputs:
       - run: echo "VSIX at $``{{ steps.package.outputs.vsix-file }}"
       ```
     value: ${{ steps.package.outputs.vsix-file }}
+  vsix-file-name:
+    description: |
+      **Filename of generated .vsix file** (package/publish operations).
+
+      **Example usage:**
+      ```yaml
+      - uses: jessehouwing/azdo-marketplace@v6
+        id: package
+        with:
+          operation: package
+
+      - run: echo "VSIX file name $``{{ steps.package.outputs.vsix-file-name }}"
+      ```
+    value: ${{ steps.package.outputs.vsix-file-name }}
 runs:
   using: composite
   steps:

--- a/packages/azdo-task/src/__tests__/main.test.ts
+++ b/packages/azdo-task/src/__tests__/main.test.ts
@@ -167,6 +167,7 @@ describe('Azure DevOps main entrypoint', () => {
     expect(validateNodeAvailableMock).toHaveBeenCalledWith(platform);
     expect(packageExtensionMock).toHaveBeenCalled();
     expect(platform.setOutput).toHaveBeenCalledWith('vsixFile', '/tmp/ext.vsix');
+    expect(platform.setOutput).toHaveBeenCalledWith('vsixFileName', 'ext.vsix');
     expect(getAuthMock).not.toHaveBeenCalled();
     expect(platform.setResult).toHaveBeenCalledWith('Succeeded', 'package completed successfully');
   });
@@ -252,6 +253,8 @@ describe('Azure DevOps main entrypoint', () => {
       expect.anything(),
       platform
     );
+    expect(platform.setOutput).toHaveBeenCalledWith('vsixFile', '/tmp/publish.vsix');
+    expect(platform.setOutput).toHaveBeenCalledWith('vsixFileName', 'publish.vsix');
     expect(platform.setResult).toHaveBeenCalledWith('Succeeded', 'publish completed successfully');
   });
 

--- a/packages/azdo-task/src/main.ts
+++ b/packages/azdo-task/src/main.ts
@@ -23,6 +23,7 @@ import {
   waitForValidation,
 } from '@extension-tasks/core';
 import * as tl from 'azure-pipelines-task-lib/task.js';
+import { basename } from 'node:path';
 import { getAuth } from './auth/index.js';
 import { AzdoAdapter } from './azdo-adapter.js';
 
@@ -41,6 +42,7 @@ function normalizeOperation(operation: string): string {
 
 function initializeDeclaredOutputs(platform: AzdoAdapter): void {
   platform.setOutput('vsixFile', '');
+  platform.setOutput('vsixFileName', '');
   platform.setOutput('extensionMetadata', '');
   platform.setOutput('proposedVersion', '');
   platform.setOutput('currentVersion', '');
@@ -280,6 +282,7 @@ async function runPackage(platform: AzdoAdapter, tfxManager: TfxManager): Promis
 
   if (result.vsixFile) {
     platform.setOutput('vsixFile', result.vsixFile);
+    platform.setOutput('vsixFileName', basename(result.vsixFile));
   }
 }
 
@@ -328,6 +331,11 @@ async function runPublish(
     tfxManager,
     platform
   );
+
+  if (result.vsixFile) {
+    platform.setOutput('vsixFile', result.vsixFile);
+    platform.setOutput('vsixFileName', basename(result.vsixFile));
+  }
 
   platform.debug(`Published: ${JSON.stringify(result)}`);
 }

--- a/packages/azdo-task/task.json
+++ b/packages/azdo-task/task.json
@@ -342,7 +342,11 @@
   "outputVariables": [
     {
       "name": "vsixFile",
-      "description": "Path to the generated .vsix file (package operation only)"
+      "description": "Path to the generated .vsix file (package/publish operations)"
+    },
+    {
+      "name": "vsixFileName",
+      "description": "Filename of the generated .vsix file (package/publish operations)"
     },
     {
       "name": "extensionMetadata",

--- a/packages/github-action/dist/node_modules/.package-lock.json
+++ b/packages/github-action/dist/node_modules/.package-lock.json
@@ -369,6 +369,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },

--- a/packages/github-action/dist/package-lock.json
+++ b/packages/github-action/dist/package-lock.json
@@ -386,6 +386,7 @@
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },

--- a/packages/github-action/src/__tests__/main.test.ts
+++ b/packages/github-action/src/__tests__/main.test.ts
@@ -160,6 +160,7 @@ describe('GitHub Action main entrypoint', () => {
     expect(validateNodeAvailableMock).toHaveBeenCalledWith(platform);
     expect(packageExtensionMock).toHaveBeenCalled();
     expect(platform.setOutput).toHaveBeenCalledWith('vsix-file', '/tmp/ext.vsix');
+    expect(platform.setOutput).toHaveBeenCalledWith('vsix-file-name', 'ext.vsix');
     expect(getAuthMock).not.toHaveBeenCalled();
     expect(platform.setResult).toHaveBeenCalledWith('Succeeded', 'package completed successfully');
   });
@@ -254,6 +255,7 @@ describe('GitHub Action main entrypoint', () => {
       platform
     );
     expect(platform.setOutput).toHaveBeenCalledWith('vsix-file', '/tmp/published.vsix');
+    expect(platform.setOutput).toHaveBeenCalledWith('vsix-file-name', 'published.vsix');
   });
 
   it('defaults publish source to manifest when use is omitted', async () => {
@@ -313,6 +315,7 @@ describe('GitHub Action main entrypoint', () => {
       platform
     );
     expect(platform.setOutput).toHaveBeenCalledWith('vsix-file', '/tmp/temp-12345.vsix');
+    expect(platform.setOutput).toHaveBeenCalledWith('vsix-file-name', 'temp-12345.vsix');
     expectNoLegacyStatusOutputs(platform);
   });
 

--- a/packages/github-action/src/main.ts
+++ b/packages/github-action/src/main.ts
@@ -24,6 +24,7 @@ import {
   waitForInstallation,
   waitForValidation,
 } from '@extension-tasks/core';
+import { basename } from 'node:path';
 import { AuthType, getAuth } from './auth/index.js';
 import { GitHubAdapter } from './github-adapter.js';
 
@@ -265,6 +266,7 @@ async function runPackage(platform: GitHubAdapter, tfxManager: TfxManager): Prom
 
   if (result.vsixFile) {
     platform.setOutput('vsix-file', result.vsixFile);
+    platform.setOutput('vsix-file-name', basename(result.vsixFile));
   }
 }
 
@@ -316,6 +318,7 @@ async function runPublish(
 
   if (result.vsixFile) {
     platform.setOutput('vsix-file', result.vsixFile);
+    platform.setOutput('vsix-file-name', basename(result.vsixFile));
   }
 
   platform.debug(`Published: ${JSON.stringify(result)}`);

--- a/publish/README.md
+++ b/publish/README.md
@@ -132,7 +132,8 @@ OR
 
 ## Outputs
 
-None
+- `vsix-file`: Path to the generated/final .vsix file used during publish
+- `vsix-file-name`: Filename of the generated/final .vsix file used during publish
 
 ## Example: Complete CI/CD Pipeline
 
@@ -198,6 +199,7 @@ jobs:
 ## GitHub Marketplace outputs
 
 - `vsix-file`: Returns the generated/final VSIX path produced during publish.
+- `vsix-file-name`: Returns the generated/final VSIX filename without the directory path.
 
 ## See Also
 

--- a/publish/action.schema.yaml
+++ b/publish/action.schema.yaml
@@ -111,3 +111,6 @@ inputs:
 outputs:
   vsix-file:
     type: string
+
+  vsix-file-name:
+    type: string

--- a/publish/action.yaml
+++ b/publish/action.yaml
@@ -366,6 +366,20 @@ outputs:
       - run: echo "VSIX at $``{{ steps.package.outputs.vsix-file }}"
       ```
     value: ${{ steps.publish.outputs.vsix-file }}
+  vsix-file-name:
+    description: |
+      **Filename of generated .vsix file** (package/publish operations).
+
+      **Example usage:**
+      ```yaml
+      - uses: jessehouwing/azdo-marketplace@v6
+        id: package
+        with:
+          operation: package
+
+      - run: echo "VSIX file name $``{{ steps.package.outputs.vsix-file-name }}"
+      ```
+    value: ${{ steps.publish.outputs.vsix-file-name }}
 runs:
   using: composite
   steps:


### PR DESCRIPTION
- Updated action schema and README to include new output `vsix-file-name` which provides the filename of the generated .vsix file.
- Modified main.ts to set the new output using the basename of the vsix file.
- Enhanced tests to verify the new output is correctly set during package and publish operations.
- Updated package-lock.json files to reflect changes in dependencies.
This pull request introduces a new output, `vsix-file-name`, across both Azure Pipelines and GitHub Actions workflows, documentation, and code. This output provides just the filename (without the directory path) of the generated `.vsix` file, complementing the existing `vsix-file` output, which provides the full path. The change is implemented in the action/task logic, schemas, documentation, and test coverage, and workflow usage is updated to reference the new output where appropriate.

**Key changes:**

### Feature Addition: Output the VSIX Filename

- Added a new output, `vsix-file-name`, to both GitHub Actions (`action.yml`, `action.schema.yaml`, `package/action.yaml`, `package/action.schema.yaml`) and Azure Pipelines (`task.json`) definitions, returning the filename of the generated `.vsix` file for package and publish operations. [[1]](diffhunk://#diff-3215daeec24ae0a5192a337c62f3e6bd6cbe58200648d03b5dbd7d8b4d16e9e6R167-R169) [[2]](diffhunk://#diff-e2395be57efc6672cf562de6f90f3d0bfbea33db7ea2df564f21d8cc8a322b5fR84-R86) [[3]](diffhunk://#diff-c8b7969f584145704b1fa4b236983c25b7999064fa28da8909b83c6a495b7efbR261-R274) [[4]](diffhunk://#diff-dbde55e090555e4154a8fbe58874bdd203bcff57ea5b21896784bfa2cef0782fL345-R349)

- Updated the implementation in both Azure Pipelines (`packages/azdo-task/src/main.ts`) and GitHub Actions (`packages/github-action/src/main.ts`) to set the `vsix-file-name` output using Node's `basename`, alongside the existing `vsix-file` output. [[1]](diffhunk://#diff-8c0ec68c4c817b3c455d97f8604fc4f3740ef6285a4250040cd8cd22abb97b12R26) [[2]](diffhunk://#diff-8c0ec68c4c817b3c455d97f8604fc4f3740ef6285a4250040cd8cd22abb97b12R45) [[3]](diffhunk://#diff-8c0ec68c4c817b3c455d97f8604fc4f3740ef6285a4250040cd8cd22abb97b12R285) [[4]](diffhunk://#diff-8c0ec68c4c817b3c455d97f8604fc4f3740ef6285a4250040cd8cd22abb97b12R335-R339) [[5]](diffhunk://#diff-a46120c1a85da5ff8800fda7cc96dfdf16c5e8dbc4cf577952cafac431994f48R27) [[6]](diffhunk://#diff-a46120c1a85da5ff8800fda7cc96dfdf16c5e8dbc4cf577952cafac431994f48R269) [[7]](diffhunk://#diff-a46120c1a85da5ff8800fda7cc96dfdf16c5e8dbc4cf577952cafac431994f48R321)

### Documentation and Usage Updates

- Updated documentation and usage examples in `README.md`, `package/README.md`, `publish/README.md`, and all relevant docs to describe and demonstrate the new `vsix-file-name` output, including migration guides and output variable mapping between GitHub Actions and Azure Pipelines. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R60) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R140) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R166) [[4]](diffhunk://#diff-91ce3953cfd5f651329f9989dfbe262d19ceea4229d0d1d03c5f31317391b018L202-R203) [[5]](diffhunk://#diff-91ce3953cfd5f651329f9989dfbe262d19ceea4229d0d1d03c5f31317391b018R243) [[6]](diffhunk://#diff-573007dedde8a5b951facde498f352d0b2d5a59b0b22cfa07976b55935a9d3abR195) [[7]](diffhunk://#diff-1319bf467c53470d2410bd7897975d1485283187875610d2a2363aa6a6e4b235R237-R241) [[8]](diffhunk://#diff-85a58860b09669e1995f036f156913ff1575c6d2fd73cf2fb150ca92d217b6b0R166) [[9]](diffhunk://#diff-85a58860b09669e1995f036f156913ff1575c6d2fd73cf2fb150ca92d217b6b0L186-R187) [[10]](diffhunk://#diff-037d15dcf3a9c89e66b49efacc634941743ba94a147dc1428f18c9814e8814d4R98) [[11]](diffhunk://#diff-037d15dcf3a9c89e66b49efacc634941743ba94a147dc1428f18c9814e8814d4R141) [[12]](diffhunk://#diff-037d15dcf3a9c89e66b49efacc634941743ba94a147dc1428f18c9814e8814d4R166) [[13]](diffhunk://#diff-898f412c24aa2b85085b868fff4f9c6cc87cdb4271576d325e48011c8a6e1432R235-R241) [[14]](diffhunk://#diff-763a9487c2b75e192a18da0abdf18c637006a79426f099655bd7d513b076f842L135-R136)

### Workflow and Pipeline Integration

- Modified workflow files (e.g., `.github/workflows/release.yml`) to use `vsix-file-name` in place of or alongside `vsix-file` for improved clarity and reliability in referencing the VSIX artifact. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L50-R50) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L244-R244) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L401-R401) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L449-R449)

### Test Coverage

- Enhanced test suites for both Azure Pipelines and GitHub Actions to assert that the new `vsix-file-name` output is set correctly during package and publish operations. [[1]](diffhunk://#diff-15048fa9e21eb20c2a62e81d2ad33e25cf6630aea6238c2ae538d4c6640772ddR170) [[2]](diffhunk://#diff-15048fa9e21eb20c2a62e81d2ad33e25cf6630aea6238c2ae538d4c6640772ddR256-R257) [[3]](diffhunk://#diff-f8da7c441269113deee060459fe49b0e7dc51e1d0dd95ea921d4b9af3395bbe7R163) [[4]](diffhunk://#diff-f8da7c441269113deee060459fe49b0e7dc51e1d0dd95ea921d4b9af3395bbe7R258) [[5]](diffhunk://#diff-f8da7c441269113deee060459fe49b0e7dc51e1d0dd95ea921d4b9af3395bbe7R318)

These changes ensure that users and downstream steps can reliably access both the full path and just the filename of packaged VSIX files, improving flexibility and clarity in CI/CD workflows.